### PR TITLE
fix: control-state sync across dashboards + toggle boolean coercion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodrix",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "workspaces": [
     "worker",

--- a/shared/widgets/iot-toggle/widget.ts
+++ b/shared/widgets/iot-toggle/widget.ts
@@ -136,7 +136,13 @@ export class IotToggleElement extends HTMLElement {
   private offValue(): string { return this.getAttribute('data-off-value') ?? 'off'; }
 
   private isOn(): boolean {
-    return String(this.#current) === this.onValue();
+    const c = this.#current;
+    if (String(c) === this.onValue()) return true;
+    if (String(c) === this.offValue()) return false;
+    if (typeof c === 'boolean') return c;
+    if (typeof c === 'number') return c !== 0;
+    const s = String(c).trim().toLowerCase();
+    return s === 'on' || s === '1' || s === 'true' || s === 'yes';
   }
 
   private toggle() {

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -374,6 +374,8 @@ export class ProjectDO extends DurableObject<Env> {
     for (const ws of this.ctx.getWebSockets()) {
       try { ws.send(payload); } catch { /* dead socket; ignore */ }
     }
+
+    this.notifyDashboards([{ variable, value: value as IngestPoint['value'] }], now);
   }
 
   async listPendingControl(): Promise<Array<{ id: string; variable: string; value: unknown }>> {


### PR DESCRIPTION
Fixes two related control-state propagation bugs (see #3).

**Bug 1 — `iot-toggle` reverts on a boolean echo.**
`isOn()` compared `String(current)` to the configured on-value, so a device echoing a JSON boolean (`true`) read as OFF and flipped the switch back. It now honors the explicit on/off value, then coerces boolean / non-zero number / `"on"/"1"/"true"/"yes"` like the device library's `asBool()`.

**Bug 2 — control changes didn't reach other open dashboards.**
`ProjectDO.addControl()` pushed to connected hardware only, so peer dashboards updated solely off the device's telemetry echo. It now also `notifyDashboards()` the commanded value, so every open dashboard reflects a control write immediately. `latest_state` stays device-reported truth (commands aren't written to it), so automations still read actual state. Because `addControl` is the single choke point, this also covers automation- and API-driven writes.

Also bumps version to 1.0.1.

Closes #3
