### PR TITLE
The device plane: author, build, flash, provision, observe, update

### DIFF
--- a/deploy/wrangler.toml
+++ b/deploy/wrangler.toml
@@ -1,7 +1,8 @@
-# nodrix deploy carrier. The Deploy to Cloudflare button clones only this
-# subdir; the build command pulls the real source from upstream over it. Don't
-# edit by hand — manage the deployment from the Cloudflare dashboard. Keep the
-# bindings in sync with the repo-root wrangler.toml.
+# nodrix deploy carrier. The Deploy to Cloudflare button clones only this subdir;
+# the build command pulls the real source from upstream over it and rebuilds the
+# deployment's wrangler.toml from this file, keeping only its Worker name,
+# account, routes, resource IDs and vars. Everything else here reaches every
+# existing deployment on its next build — keep it in sync with the root config.
 name = "nodrix"
 main = "worker/src/index.ts"
 compatibility_date = "2025-05-01"

--- a/scripts/build-from-upstream.sh
+++ b/scripts/build-from-upstream.sh
@@ -9,9 +9,11 @@
 # source of truth — meaning code changes in upstream never reach them. With
 # this script, every deploy:
 #
-#   1. Preserves the user's wrangler.toml (which has their resource IDs,
-#      filled by the Deploy button on day 1 and never changed since).
-#   2. Replaces every other file with the upstream source's contents.
+#   1. Replaces every file with the upstream source's contents.
+#   2. Rebuilds wrangler.toml from upstream's carrier template, keeping only the
+#      deployment's identity (Worker name, account, routes, resource IDs, vars).
+#      Keeping the whole file instead froze the topology at day 1, so a binding
+#      or flag added upstream never reached anyone who had already deployed.
 #   3. Runs upstream's build pipeline.
 #
 # Result: the user's clone is functionally a config carrier. Code = upstream.
@@ -31,6 +33,7 @@ UPSTREAM_REPO="${NODRIX_UPSTREAM_REPO:-decoded-cipher/nodrix}"
 DEPLOY_CHANNEL="${NODRIX_DEPLOY_CHANNEL:-release}"
 UPSTREAM_DIR="/tmp/nodrix-upstream"
 WRANGLER_BACKUP="/tmp/nodrix-wrangler.toml"
+WRANGLER_MERGED="/tmp/nodrix-wrangler.merged.toml"
 
 if [ -z "${WORKERS_CI_COMMIT_SHA:-}" ]; then
   echo "[build-from-upstream] not in Workers Builds CI — running local build chain"
@@ -43,7 +46,7 @@ fi
 
 echo "[build-from-upstream] CI build — pulling upstream ${UPSTREAM_REPO} (${DEPLOY_CHANNEL} channel)"
 
-# 1. Preserve user's wrangler.toml.
+# 1. Save the deployment's wrangler.toml; step 4 merges it back.
 if [ ! -f wrangler.toml ]; then
   echo "[build-from-upstream] no wrangler.toml in cwd — refusing to proceed" >&2
   exit 1
@@ -114,8 +117,17 @@ for dir in web worker scripts; do
     done
 done
 
-# 4. Restore user's wrangler.toml in case upstream had its own (which it does).
-cp "${WRANGLER_BACKUP}" wrangler.toml
+# 4. Rebuild wrangler.toml. This script comes from master but the clone is the
+#    release tag, so a release predating the merge script falls back instead of
+#    failing.
+if [ -f scripts/merge-wrangler.ts ] && [ -f ./deploy/wrangler.toml ]; then
+  echo "[build-from-upstream] merging deployment identity into upstream wrangler.toml"
+  bun scripts/merge-wrangler.ts "${WRANGLER_BACKUP}" ./deploy/wrangler.toml > "${WRANGLER_MERGED}"
+  mv "${WRANGLER_MERGED}" wrangler.toml
+else
+  echo "[build-from-upstream] upstream has no merge script — keeping wrangler.toml as-is"
+  cp "${WRANGLER_BACKUP}" wrangler.toml
+fi
 
 # 4b. Drop the nested deploy/ that the overlay just brought in. The clone root
 #     IS the deploy carrier; upstream's own deploy/ dir is dead weight here and

--- a/scripts/merge-wrangler.test.ts
+++ b/scripts/merge-wrangler.test.ts
@@ -1,0 +1,116 @@
+// Getting this wrong on a live deployment points it at resources it doesn't own,
+// or renames the Worker. Run with `bun test scripts/merge-wrangler.test.ts`.
+
+import { test, expect } from 'bun:test';
+import { mergeWrangler } from './merge-wrangler';
+
+// Renamed, on a custom domain, tracking a fork, and predating three template changes.
+const DEPLOYMENT = `name = "home-iot"
+main = "worker/src/index.ts"
+compatibility_date = "2025-05-01"
+compatibility_flags = ["nodejs_compat"]
+account_id = "acc_123"
+routes = [
+  { pattern = "iot.example.com", custom_domain = true }
+]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "home-iot-db"
+database_id = "aaaa-bbbb-cccc"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "kv_deadbeef"
+
+[[r2_buckets]]
+binding = "R2"
+bucket_name = "home-iot-telemetry"
+
+[vars]
+NODRIX_UPSTREAM_REPO = "someone/nodrix-fork"
+`;
+
+const TEMPLATE = `name = "nodrix"
+main = "worker/src/index.ts"
+compatibility_date = "2026-01-15"
+compatibility_flags = ["nodejs_compat"]
+
+[build]
+command = "curl -fsSL https://example.invalid/build.sh | bash"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "nodrix"
+database_id = "PLACEHOLDER_FILLED_BY_DEPLOY_OR_WRANGLER"
+migrations_dir = "worker/src/platform/db/migrations"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "PLACEHOLDER_FILLED_BY_DEPLOY_OR_WRANGLER"
+
+[[r2_buckets]]
+binding = "R2"
+bucket_name = "nodrix-telemetry"
+
+[[durable_objects.bindings]]
+name = "PROJECT_DO"
+class_name = "ProjectDO"
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["DeviceDO"]
+
+[vars]
+NODRIX_UPSTREAM_REPO = "decoded-cipher/nodrix"
+NODRIX_FEATURE_FLAG = "on"
+
+[triggers]
+crons = ["0 0 * * *"]
+`;
+
+const merged = mergeWrangler(DEPLOYMENT, TEMPLATE);
+
+test('keeps the deployment worker name', () => {
+  expect(merged).toContain('name = "home-iot"');
+  expect(merged).not.toContain('name = "nodrix"');
+});
+
+test('keeps resource ids the deployment owns', () => {
+  expect(merged).toContain('database_id = "aaaa-bbbb-cccc"');
+  expect(merged).toContain('database_name = "home-iot-db"');
+  expect(merged).toContain('id = "kv_deadbeef"');
+  expect(merged).toContain('bucket_name = "home-iot-telemetry"');
+  expect(merged).not.toContain('PLACEHOLDER');
+});
+
+test('keeps account and routes the template never declares', () => {
+  expect(merged).toContain('account_id = "acc_123"');
+  expect(merged).toContain('pattern = "iot.example.com"');
+});
+
+test('takes compatibility settings and build config from upstream', () => {
+  expect(merged).toContain('compatibility_date = "2026-01-15"');
+  expect(merged).toContain('https://example.invalid/build.sh');
+});
+
+test('takes new bindings, migrations and triggers from upstream', () => {
+  expect(merged).toContain('class_name = "ProjectDO"');
+  expect(merged).toContain('new_sqlite_classes = ["DeviceDO"]');
+  expect(merged).toContain('crons = ["0 0 * * *"]');
+  expect(merged).toContain('migrations_dir = "worker/src/platform/db/migrations"');
+});
+
+test('keeps an overridden var and adds one the deployment predates', () => {
+  expect(merged).toContain('NODRIX_UPSTREAM_REPO = "someone/nodrix-fork"');
+  expect(merged).toContain('NODRIX_FEATURE_FLAG = "on"');
+});
+
+test('is idempotent against its own output', () => {
+  expect(mergeWrangler(merged, TEMPLATE)).toBe(merged);
+});
+
+test('a fresh deployment carrying only placeholders is left as the template', () => {
+  const fresh = mergeWrangler(TEMPLATE, TEMPLATE);
+  expect(fresh).toBe(TEMPLATE);
+});

--- a/scripts/merge-wrangler.ts
+++ b/scripts/merge-wrangler.ts
@@ -1,0 +1,171 @@
+// Rebuilds a deployment's wrangler.toml: bindings, flags and build config from
+// upstream's carrier template, identity from the deployment's own file.
+//
+// Keeping the deployment's file verbatim froze its topology at whatever the
+// Deploy button wrote on day one; taking upstream's verbatim would rename the
+// Worker, creating a second one and orphaning the live one.
+
+import { readFileSync } from 'node:fs';
+
+const PRESERVED_TOP_KEYS = ['name', 'account_id', 'workers_dev', 'preview_urls', 'route', 'routes'];
+
+const PRESERVED_RESOURCE_KEYS: Record<string, string[]> = {
+  d1_databases: ['database_id', 'database_name'],
+  kv_namespaces: ['id'],
+  r2_buckets: ['bucket_name'],
+};
+
+type Section = { header: string; lines: string[] };
+
+function keyOf(line: string): string | null {
+  const m = /^\s*([A-Za-z_][A-Za-z0-9_.-]*)\s*=/.exec(line);
+  return m ? m[1]! : null;
+}
+
+// TOML arrays and inline tables can span lines; those join into one entry.
+function unclosed(text: string): boolean {
+  let depth = 0;
+  let quote = '';
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]!;
+    if (quote) {
+      if (c === '\\') i++;
+      else if (c === quote) quote = '';
+      continue;
+    }
+    if (c === '"' || c === "'") quote = c;
+    else if (c === '#') break;
+    else if (c === '[' || c === '{') depth++;
+    else if (c === ']' || c === '}') depth--;
+  }
+  return depth > 0;
+}
+
+function parse(text: string): Section[] {
+  const sections: Section[] = [{ header: '', lines: [] }];
+  const raw = text.split('\n');
+  for (let i = 0; i < raw.length; i++) {
+    let line = raw[i]!;
+    if (line.trim().startsWith('[')) {
+      sections.push({ header: line.trim(), lines: [] });
+      continue;
+    }
+    if (keyOf(line)) {
+      while (unclosed(line) && i + 1 < raw.length) line += '\n' + raw[++i]!;
+    }
+    sections[sections.length - 1]!.lines.push(line);
+  }
+  return sections;
+}
+
+function valueOf(line: string): string {
+  const eq = line.indexOf('=');
+  return line.slice(eq + 1).trim().replace(/\s*#.*$/, '').replace(/^["']|["']$/g, '');
+}
+
+function lookup(section: Section, key: string): string | undefined {
+  for (const l of section.lines) if (keyOf(l) === key) return l;
+  return undefined;
+}
+
+function arrayName(header: string): string | null {
+  const m = /^\[\[([A-Za-z0-9_.-]+)\]\]$/.exec(header);
+  return m ? m[1]! : null;
+}
+
+export function mergeWrangler(sourceText: string, templateText: string): string {
+  const source = parse(sourceText);
+  const template = parse(templateText);
+
+  const sourceTop = source[0]!;
+  const sourceResources = new Map<string, Section>();
+  let sourceVars: Section | undefined;
+  for (const s of source) {
+    const name = arrayName(s.header);
+    if (name && name in PRESERVED_RESOURCE_KEYS) {
+      const binding = lookup(s, 'binding');
+      if (binding) sourceResources.set(`${name}:${valueOf(binding)}`, s);
+    } else if (s.header === '[vars]') {
+      sourceVars = s;
+    }
+  }
+
+  const out: string[] = [];
+  const usedTopKeys = new Set<string>();
+
+  for (const s of template) {
+    if (s.header) out.push(s.header);
+
+    const name = arrayName(s.header);
+    const resourceKeys = name ? PRESERVED_RESOURCE_KEYS[name] : undefined;
+    let resource: Section | undefined;
+    if (resourceKeys) {
+      const binding = lookup(s, 'binding');
+      if (binding) {
+        resource = sourceResources.get(`${name}:${valueOf(binding)}`);
+        if (!resource) {
+          console.error(
+            `[merge-wrangler] ${name} binding ${valueOf(binding)} is new upstream — this deployment has no id for it`
+          );
+        }
+      }
+    }
+
+    for (const line of s.lines) {
+      const key = keyOf(line);
+      if (!key) {
+        out.push(line);
+        continue;
+      }
+      if (!s.header && PRESERVED_TOP_KEYS.includes(key)) {
+        const own = lookup(sourceTop, key);
+        usedTopKeys.add(key);
+        out.push(own ?? line);
+        continue;
+      }
+      if (resource && resourceKeys!.includes(key)) {
+        out.push(lookup(resource, key) ?? line);
+        continue;
+      }
+      if (s.header === '[vars]' && sourceVars) {
+        out.push(lookup(sourceVars, key) ?? line);
+        continue;
+      }
+      out.push(line);
+    }
+
+    // Custom domains and account ids the template never declares.
+    if (!s.header) {
+      const extra = PRESERVED_TOP_KEYS.filter((k) => !usedTopKeys.has(k) && lookup(sourceTop, k));
+      if (extra.length) {
+        let at = out.length;
+        while (at > 0 && !keyOf(out[at - 1]!)) at--;
+        out.splice(at, 0, ...extra.map((k) => lookup(sourceTop, k)!));
+      }
+    }
+    if (s.header === '[vars]' && sourceVars) {
+      const declared = new Set(s.lines.map(keyOf).filter(Boolean));
+      for (const line of sourceVars.lines) {
+        const k = keyOf(line);
+        if (k && !declared.has(k)) out.push(line);
+      }
+    }
+  }
+
+  if (sourceVars && !template.some((s) => s.header === '[vars]')) {
+    out.push('', '[vars]', ...sourceVars.lines.filter((l) => keyOf(l)));
+  }
+
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').replace(/\n*$/, '\n');
+}
+
+if (import.meta.main) {
+  const [, , sourcePath, templatePath] = process.argv;
+  if (!sourcePath || !templatePath) {
+    console.error('usage: merge-wrangler.ts <deployment.toml> <upstream-template.toml>');
+    process.exit(1);
+  }
+  process.stdout.write(
+    mergeWrangler(readFileSync(sourcePath, 'utf8'), readFileSync(templatePath, 'utf8'))
+  );
+}

--- a/shared/blocks/index.ts
+++ b/shared/blocks/index.ts
@@ -26,6 +26,7 @@ export type BlockFieldType =
   | 'number'
   | 'boolean'
   | 'variable'
+  | 'device'
   | 'integration'
   | 'time'
   | 'weekdays';

--- a/shared/blocks/triggers.ts
+++ b/shared/blocks/triggers.ts
@@ -14,6 +14,12 @@ export const TRIGGER_CATALOG = [
     fields: [
       { key: 'variable', label: 'Variable', type: 'variable', required: true },
       {
+        key: 'device',
+        label: 'Device',
+        type: 'device',
+        hint: 'Leave as any device to fire whichever board reports it.',
+      },
+      {
         key: 'operator',
         label: 'Condition',
         type: 'select',

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "@nodrix/widgets-shared": "*",
     "@vue-flow/core": "^1.48.2",
     "better-auth": "^1.6.11",
+    "esptool-js": "^0.6.1",
     "grid-layout-plus": "^1.1.1",
     "pinia": "^2.3.0",
     "reka-ui": "^2.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@types/w3c-web-serial": "^1.0.8",
     "@vitejs/plugin-vue": "^5.2.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.6.3",

--- a/web/package.json
+++ b/web/package.json
@@ -10,11 +10,16 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@codemirror/lang-cpp": "^6.0.3",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.43.9",
     "@nodrix/blocks-shared": "*",
     "@nodrix/integrations-shared": "*",
     "@nodrix/widgets-shared": "*",
     "@vue-flow/core": "^1.48.2",
     "better-auth": "^1.6.11",
+    "codemirror": "^6.0.2",
     "esptool-js": "^0.6.1",
     "grid-layout-plus": "^1.1.1",
     "pinia": "^2.3.0",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -47,6 +47,18 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
   }
 }
 
+async function requestBytes(path: string): Promise<ArrayBuffer> {
+  progress.start();
+  try {
+    const res = await fetch(path, { credentials: 'include' });
+    if (res.status === 401) unauthorizedHandler?.();
+    if (!res.ok) throw new ApiError(res.status, await res.json().catch(() => null));
+    return await res.arrayBuffer();
+  } finally {
+    progress.done();
+  }
+}
+
 // Collapse concurrent identical GETs into one network request — e.g. two
 // components mounting at once both calling the same loader. The promise is shared
 // while in flight and dropped as soon as it settles, so this is a dedup of
@@ -63,6 +75,7 @@ function getDeduped<T>(path: string): Promise<T> {
 
 export const api = {
   get: <T>(path: string) => getDeduped<T>(path),
+  bytes: (path: string) => requestBytes(path),
   post: <T>(path: string, body?: unknown) => request<T>('POST', path, body),
   put: <T>(path: string, body?: unknown) => request<T>('PUT', path, body),
   patch: <T>(path: string, body?: unknown) => request<T>('PATCH', path, body),

--- a/web/src/builder/grid.ts
+++ b/web/src/builder/grid.ts
@@ -20,5 +20,6 @@ export function normalizeLayout(layout: Layout): Layout {
     }),
     ...(layout.mobile !== undefined ? { mobile: layout.mobile } : {}),
     ...(layout.refresh !== undefined ? { refresh: layout.refresh } : {}),
+    ...(layout.device !== undefined ? { device: layout.device } : {}),
   };
 }

--- a/web/src/components/CodeEditor.vue
+++ b/web/src/components/CodeEditor.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { basicSetup } from 'codemirror';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { cpp } from '@codemirror/lang-cpp';
+import { oneDark } from '@codemirror/theme-one-dark';
+
+const props = defineProps<{ modelValue: string }>();
+const emit = defineEmits<{ 'update:modelValue': [string] }>();
+
+const host = ref<HTMLElement | null>(null);
+let view: EditorView | null = null;
+
+onMounted(() => {
+  view = new EditorView({
+    parent: host.value!,
+    state: EditorState.create({
+      doc: props.modelValue,
+      extensions: [
+        basicSetup,
+        cpp(),
+        oneDark,
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) emit('update:modelValue', u.state.doc.toString());
+        }),
+      ],
+    }),
+  });
+});
+
+// Echoing the user's own keystrokes back would reset the cursor every character.
+watch(
+  () => props.modelValue,
+  (next) => {
+    if (!view || next === view.state.doc.toString()) return;
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: next } });
+  }
+);
+
+onBeforeUnmount(() => view?.destroy());
+</script>
+
+<template>
+  <div ref="host" class="overflow-hidden rounded-xl border border-neutral-200 text-sm dark:border-neutral-800" />
+</template>

--- a/web/src/composables/useEspFlasher.ts
+++ b/web/src/composables/useEspFlasher.ts
@@ -1,0 +1,79 @@
+import { ref } from 'vue';
+import { ESPLoader, Transport } from 'esptool-js';
+import { useSerialPort, emit } from './useSerialPort';
+
+export type FlashPart = { data: Uint8Array; address: number };
+
+export type FlashPhase = 'idle' | 'connecting' | 'writing' | 'done' | 'failed';
+
+// main() handshakes with the ROM loader at 115200, then negotiates up to this.
+const WRITE_BAUD = 460800;
+
+const phase = ref<FlashPhase>('idle');
+const progress = ref(0);
+const chip = ref<string | null>(null);
+const error = ref<string | null>(null);
+
+// esptool-js reports out of band — none of this arrives over the port, which is
+// speaking binary to the ROM loader at the time.
+const terminal = {
+  clean: () => {},
+  write: (data: string) => { if (data.trim()) emit('flash', data.trim()); },
+  writeLine: (data: string) => { if (data.trim()) emit('flash', data.trim()); },
+};
+
+export function useEspFlasher() {
+  const { claim } = useSerialPort();
+
+  async function flash(parts: FlashPart[]): Promise<boolean> {
+    if (!parts.length) throw new Error('Nothing to flash');
+    phase.value = 'connecting';
+    progress.value = 0;
+    error.value = null;
+
+    const total = parts.reduce((n, p) => n + p.data.length, 0);
+    const written = new Map<number, number>();
+
+    try {
+      await claim('flash', async (port) => {
+        const transport = new Transport(port, false);
+        const loader = new ESPLoader({
+          transport,
+          baudrate: WRITE_BAUD,
+          terminal,
+        });
+        try {
+          chip.value = await loader.main();
+          phase.value = 'writing';
+          await loader.writeFlash({
+            fileArray: parts,
+            flashMode: 'keep',
+            flashFreq: 'keep',
+            flashSize: 'keep',
+            eraseAll: false,
+            compress: true,
+            reportProgress: (fileIndex, bytes) => {
+              written.set(fileIndex, bytes);
+              const done = [...written.values()].reduce((n, v) => n + v, 0);
+              progress.value = total ? Math.min(1, done / total) : 0;
+            },
+          });
+          // Without this the board sits in the ROM loader until it's unplugged.
+          await loader.after();
+        } finally {
+          await transport.disconnect();
+        }
+      });
+      phase.value = 'done';
+      progress.value = 1;
+      return true;
+    } catch (e) {
+      error.value = (e as Error).message;
+      emit('flash', `Failed: ${error.value}`);
+      phase.value = 'failed';
+      return false;
+    }
+  }
+
+  return { flash, phase, progress, chip, error };
+}

--- a/web/src/composables/useSerialDiagnosis.ts
+++ b/web/src/composables/useSerialDiagnosis.ts
@@ -1,0 +1,105 @@
+import { computed, type ComputedRef } from 'vue';
+import { useSerialLog, type LogEntry } from './useSerialLog';
+
+export type Diagnosis = {
+  tone: 'ok' | 'warn' | 'error';
+  headline: string;
+  detail?: string;
+};
+
+type Rule = { re: RegExp; build: (m: RegExpMatchArray) => Diagnosis };
+
+const RULES: Rule[] = [
+  {
+    re: /^no wifi network set/,
+    build: () => ({
+      tone: 'error',
+      headline: 'No Wi-Fi network configured',
+      detail: 'The sketch never called addAP(), so it has nothing to join.',
+    }),
+  },
+  {
+    re: /^connect refused/,
+    build: () => ({
+      tone: 'error',
+      headline: 'The server refused the connection',
+      detail: 'The socket never opened once. The token is wrong, or the host is.',
+    }),
+  },
+  {
+    re: /-> 401/,
+    build: () => ({ tone: 'error', headline: 'Token rejected', detail: 'This token is not valid for this instance.' }),
+  },
+  {
+    re: /-> 403/,
+    build: () => ({ tone: 'error', headline: 'Token has no access to this project' }),
+  },
+  {
+    re: /-> 404/,
+    build: () => ({ tone: 'error', headline: 'No such endpoint', detail: 'The host is probably wrong.' }),
+  },
+  {
+    re: /-> 429/,
+    build: () => ({ tone: 'warn', headline: 'Rate limited', detail: 'The board is sending faster than the instance accepts.' }),
+  },
+  {
+    re: /-> -\d+ \(no connection/,
+    build: () => ({
+      tone: 'error',
+      headline: "Can't reach the server",
+      detail: 'DNS, TLS or the network dropped it before any reply came back.',
+    }),
+  },
+  {
+    re: /^socket error/,
+    build: () => ({ tone: 'error', headline: 'Socket error' }),
+  },
+  {
+    re: /^server error:\s*(\S+)/,
+    build: (m) => ({ tone: 'error', headline: `Server rejected the message`, detail: `It replied with ${m[1]}.` }),
+  },
+  {
+    re: /^connected$/,
+    build: () => ({ tone: 'ok', headline: 'Connected' }),
+  },
+  {
+    re: /^disconnected$/,
+    build: () => ({ tone: 'warn', headline: 'Disconnected', detail: 'The link was up and dropped. It will retry.' }),
+  },
+];
+
+function match(entry: LogEntry): Diagnosis | null {
+  if (entry.tag !== 'nodrix') return null;
+  for (const rule of RULES) {
+    const m = entry.text.match(rule.re);
+    if (m) return rule.build(m);
+  }
+  return null;
+}
+
+// Wi-Fi state is separate from cloud state: knowing the network is up is what
+// turns "disconnected" into a statement about the server rather than the radio.
+function wifiUp(entries: LogEntry[]): boolean {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i]!;
+    if (e.tag === 'nodrix' && /^wifi connected/.test(e.text)) return true;
+  }
+  return false;
+}
+
+export function diagnose(list: LogEntry[]): Diagnosis | null {
+  for (let i = list.length - 1; i >= 0; i--) {
+    const found = match(list[i]!);
+    if (!found) continue;
+    if (found.tone !== 'ok' && wifiUp(list)) {
+      return { ...found, detail: `Wi-Fi is up. ${found.detail ?? ''}`.trim() };
+    }
+    return found;
+  }
+  return null;
+}
+
+export function useSerialDiagnosis(): ComputedRef<Diagnosis | null> {
+  const { entries } = useSerialLog();
+  return computed(() => diagnose(entries.value));
+}

--- a/web/src/composables/useSerialLog.ts
+++ b/web/src/composables/useSerialLog.ts
@@ -1,0 +1,117 @@
+import { computed, ref, shallowRef } from 'vue';
+import { useSerialPort, type LogLine, type LogSource } from './useSerialPort';
+
+export type LogLevel = 'info' | 'ok' | 'warn' | 'error' | 'system';
+export type LogEntry = {
+  id: number;
+  at: number;
+  source: LogSource;
+  text: string;
+  level: LogLevel;
+  tag?: string;
+};
+
+const MAX_ENTRIES = 2000;
+// A wrong baud rate reads as replacement and control characters, not silence.
+const GARBLED_RATIO = 0.2;
+const GARBLED_CHARS = /[\uFFFD\u0000-\u0008\u000B\u000C\u000E-\u001F]/g;
+
+const BOOT_PREFIXES = ['rst:0x', 'ets ', 'load 0x', 'configsip:', 'clk_drv:', 'mode:DIO', 'entry 0x'];
+
+const NODRIX_LEVELS: [RegExp, LogLevel][] = [
+  [/^no wifi network set/, 'error'],
+  [/^wifi connected/, 'ok'],
+  [/^connected$/, 'ok'],
+  [/^disconnected$/, 'warn'],
+  [/^server error/, 'error'],
+  [/^unhandled control/, 'warn'],
+  [/^key dropped/, 'warn'],
+  [/^telemetry buffer full/, 'warn'],
+];
+
+function classify(line: LogLine, id: number): LogEntry {
+  const base = { id, at: line.at, source: line.source, text: line.text };
+  if (line.source === 'flash') return { ...base, level: 'info', tag: 'flash' };
+  if (line.source === 'system') return { ...base, level: 'system' };
+
+  const nodrix = /^\[nodrix\]\s*(.*)$/.exec(line.text);
+  if (nodrix) {
+    const body = nodrix[1] ?? '';
+    const match = NODRIX_LEVELS.find(([re]) => re.test(body));
+    return { ...base, text: body, level: match?.[1] ?? 'info', tag: 'nodrix' };
+  }
+
+  const idf = /^([EWIDV])\s\(\d+\)\s/.exec(line.text);
+  if (idf) {
+    const level: LogLevel = idf[1] === 'E' ? 'error' : idf[1] === 'W' ? 'warn' : 'info';
+    return { ...base, level, tag: 'esp' };
+  }
+
+  if (BOOT_PREFIXES.some((p) => line.text.startsWith(p))) return { ...base, level: 'system', tag: 'boot' };
+
+  return { ...base, level: 'info' };
+}
+
+const entries = shallowRef<LogEntry[]>([]);
+const paused = ref(false);
+let held: LogEntry[] = [];
+let queue: LogEntry[] = [];
+let frame: number | null = null;
+let nextId = 1;
+
+function cap(list: LogEntry[]): LogEntry[] {
+  return list.length > MAX_ENTRIES ? list.slice(list.length - MAX_ENTRIES) : list;
+}
+
+// A board at 115200 can outrun per-line reactivity, so commit once a frame.
+function schedule() {
+  if (frame !== null) return;
+  frame = requestAnimationFrame(() => {
+    frame = null;
+    if (!queue.length) return;
+    entries.value = cap(entries.value.concat(queue));
+    queue = [];
+  });
+}
+
+useSerialPort().onLine((line) => {
+  const entry = classify(line, nextId++);
+  if (paused.value) {
+    held = cap(held.concat(entry));
+    return;
+  }
+  queue.push(entry);
+  schedule();
+});
+
+const garbled = computed(() => {
+  const recent = entries.value.filter((e) => e.source === 'device').slice(-20);
+  if (recent.length < 5) return false;
+  const text = recent.map((e) => e.text).join('');
+  if (!text.length) return false;
+  return (text.match(GARBLED_CHARS) ?? []).length / text.length > GARBLED_RATIO;
+});
+
+function setPaused(on: boolean) {
+  paused.value = on;
+  if (!on && held.length) {
+    entries.value = cap(entries.value.concat(held));
+    held = [];
+  }
+}
+
+function clear() {
+  entries.value = [];
+  queue = [];
+  held = [];
+}
+
+function toText(): string {
+  return entries.value
+    .map((e) => `${new Date(e.at).toISOString().slice(11, 23)}  ${e.tag ? `[${e.tag}] ` : ''}${e.text}`)
+    .join('\n');
+}
+
+export function useSerialLog() {
+  return { entries, paused, garbled, setPaused, clear, toText };
+}

--- a/web/src/composables/useSerialPort.ts
+++ b/web/src/composables/useSerialPort.ts
@@ -1,0 +1,216 @@
+// Single owner of the page's one SerialPort. The monitor holds an exclusive
+// reader and the flasher needs it closed, so both go through claim().
+
+import { ref, shallowRef } from 'vue';
+
+export type PortMode = 'monitor' | 'flash' | 'provision';
+export type PortState = 'unsupported' | 'closed' | 'opening' | 'open' | 'busy';
+
+// Flash progress comes from esptool-js, not over the port.
+export type LogSource = 'device' | 'flash' | 'system';
+export type LogLine = { source: LogSource; text: string; at: number };
+
+export const serialSupported =
+  typeof navigator !== 'undefined' && 'serial' in navigator && window.isSecureContext;
+
+// 74880 is the ESP8266 boot ROM's rate; its reset banner is mojibake elsewhere.
+export const BAUD_RATES = [9600, 19200, 38400, 57600, 74880, 115200, 230400, 460800, 921600];
+
+// The SDK dots through a Wi-Fi connect without newlines.
+const PARTIAL_LINE_FLUSH_MS = 250;
+
+const port = shallowRef<SerialPort | null>(null);
+const state = ref<PortState>(serialSupported ? 'closed' : 'unsupported');
+const mode = ref<PortMode | null>(null);
+const baudRate = ref(115200);
+const lastError = ref<string | null>(null);
+
+const listeners = new Set<(line: LogLine) => void>();
+let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+let readLoop: Promise<void> | null = null;
+let carry = '';
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+let chain: Promise<unknown> = Promise.resolve();
+function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+  const run = chain.then(fn, fn);
+  chain = run.catch(() => {});
+  return run;
+}
+
+function deliver(source: LogSource, text: string) {
+  const line = { source, text, at: Date.now() };
+  for (const fn of listeners) fn(line);
+}
+
+export function emit(source: LogSource, text: string) {
+  deliver(source, text);
+}
+
+function flushCarry() {
+  if (!carry) return;
+  deliver('device', carry);
+  carry = '';
+}
+
+function absorb(chunk: string) {
+  carry += chunk.replace(/\r/g, '');
+  const parts = carry.split('\n');
+  carry = parts.pop() ?? '';
+  for (const line of parts) deliver('device', line);
+  if (flushTimer) clearTimeout(flushTimer);
+  if (carry) flushTimer = setTimeout(flushCarry, PARTIAL_LINE_FLUSH_MS);
+}
+
+async function pump(p: SerialPort) {
+  const decoder = new TextDecoder();
+  while (p.readable && mode.value === 'monitor') {
+    reader = p.readable.getReader();
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        if (value) absorb(decoder.decode(value, { stream: true }));
+      }
+    } catch (e) {
+      lastError.value = (e as Error).message;
+      return;
+    } finally {
+      try { reader.releaseLock(); } catch { /* already released */ }
+      reader = null;
+    }
+  }
+}
+
+async function teardown() {
+  mode.value = null;
+  if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+  flushCarry();
+  if (reader) { try { await reader.cancel(); } catch { /* stream already dead */ } }
+  if (readLoop) { try { await readLoop; } catch { /* surfaced via lastError */ } readLoop = null; }
+  const p = port.value;
+  if (p) { try { await p.close(); } catch { /* already closed */ } }
+  state.value = 'closed';
+}
+
+async function request(): Promise<boolean> {
+  if (!serialSupported) throw new Error('Web Serial is unavailable in this browser');
+  try {
+    port.value = await navigator.serial.requestPort();
+    lastError.value = null;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function beginMonitor(p: SerialPort, baud: number, note: string): Promise<void> {
+  state.value = 'opening';
+  try {
+    await p.open({ baudRate: baud });
+  } catch (e) {
+    state.value = 'closed';
+    lastError.value = (e as Error).message;
+    throw e;
+  }
+  baudRate.value = baud;
+  mode.value = 'monitor';
+  state.value = 'open';
+  deliver('system', `${note} at ${baud} baud`);
+  readLoop = pump(p).finally(() => {
+    if (mode.value === 'monitor') { mode.value = null; state.value = 'closed'; }
+  });
+}
+
+function startMonitor(baud: number): Promise<void> {
+  return enqueue(async () => {
+    const p = port.value;
+    if (!p) throw new Error('No port selected');
+    if (mode.value === 'monitor') return;
+    await beginMonitor(p, baud, 'Connected');
+  });
+}
+
+function stopMonitor(): Promise<void> {
+  return enqueue(teardown);
+}
+
+// Web Serial can't reconfigure a live port; buffered output is lost.
+function setBaud(baud: number): Promise<void> {
+  return enqueue(async () => {
+    if (baud === baudRate.value && mode.value === 'monitor') return;
+    const p = port.value;
+    const wasMonitoring = mode.value === 'monitor';
+    if (wasMonitoring) await teardown();
+    baudRate.value = baud;
+    if (wasMonitoring && p) await beginMonitor(p, baud, 'Reconnected');
+  });
+}
+
+// esptool-js opens and closes the port itself, so hand it over closed.
+function claim<T>(next: PortMode, fn: (raw: SerialPort) => Promise<T>): Promise<T> {
+  return enqueue(async () => {
+    const p = port.value;
+    if (!p) throw new Error('No port selected');
+    const wasMonitoring = mode.value === 'monitor';
+    const baud = baudRate.value;
+    await teardown();
+    mode.value = next;
+    state.value = 'busy';
+    deliver('system', `Monitor released — port handed to ${next}`);
+    try {
+      return await fn(p);
+    } finally {
+      mode.value = null;
+      state.value = 'closed';
+      if (wasMonitoring) {
+        try { await beginMonitor(p, baud, 'Monitor resumed'); } catch { /* surfaced as lastError */ }
+      }
+    }
+  });
+}
+
+async function write(data: string | Uint8Array): Promise<void> {
+  const p = port.value;
+  if (!p?.writable) throw new Error('Port is not open for writing');
+  const writer = p.writable.getWriter();
+  try {
+    await writer.write(typeof data === 'string' ? new TextEncoder().encode(data) : data);
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+function onLine(fn: (line: LogLine) => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+if (serialSupported) {
+  navigator.serial.addEventListener('disconnect', (e) => {
+    if (e.target !== port.value) return;
+    port.value = null;
+    mode.value = null;
+    state.value = 'closed';
+    lastError.value = 'Device disconnected';
+    deliver('system', 'Device disconnected');
+  });
+}
+
+export function useSerialPort() {
+  return {
+    supported: serialSupported,
+    port,
+    state,
+    mode,
+    baudRate,
+    lastError,
+    request,
+    startMonitor,
+    stopMonitor,
+    setBaud,
+    claim,
+    write,
+    onLine,
+  };
+}

--- a/web/src/layouts/Sidebar.vue
+++ b/web/src/layouts/Sidebar.vue
@@ -22,7 +22,7 @@ const hasProject = computed(() => projId.value !== '');
 
 type IconName =
   | 'home' | 'folder' | 'dashboards' | 'variable' | 'bolt'
-  | 'integrations' | 'users' | 'key' | 'settings' | 'audit';
+  | 'integrations' | 'users' | 'key' | 'settings' | 'audit' | 'device';
 
 type NavItem = {
   label: string;
@@ -57,6 +57,13 @@ const projectScoped = computed<NavItem[]>(() => {
       disabled: !hasProject.value,
       matchPath: (path) =>
         path === `/p/${id}/dashboards` || path.startsWith(`/p/${id}/d/`),
+    },
+    {
+      label: 'Device',
+      to: `/p/${id}/device`,
+      icon: 'device',
+      disabled: !hasProject.value,
+      matchPath: (path) => path.startsWith(`/p/${id}/device`),
     },
     {
       label: 'Automations',
@@ -105,6 +112,7 @@ const ICON_PATHS: Record<IconName, string> = {
   key: 'M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z',
   settings: 'M4.5 12a7.5 7.5 0 0 0 .104 1.243l-1.32 1.02a.75.75 0 0 0-.176.957l1.5 2.598a.75.75 0 0 0 .912.328l1.561-.624a7.45 7.45 0 0 0 2.155 1.244l.236 1.66a.75.75 0 0 0 .742.643h3a.75.75 0 0 0 .742-.643l.237-1.66a7.45 7.45 0 0 0 2.154-1.244l1.561.624a.75.75 0 0 0 .912-.328l1.5-2.598a.75.75 0 0 0-.176-.957l-1.32-1.02A7.51 7.51 0 0 0 19.5 12c0-.42-.035-.832-.103-1.232l1.319-1.02a.75.75 0 0 0 .176-.958l-1.5-2.598a.75.75 0 0 0-.912-.327l-1.561.624A7.46 7.46 0 0 0 14.764 5.245l-.236-1.66A.75.75 0 0 0 13.786 3h-3a.75.75 0 0 0-.742.643l-.237 1.66a7.45 7.45 0 0 0-2.154 1.244l-1.561-.624a.75.75 0 0 0-.912.327l-1.5 2.598a.75.75 0 0 0 .176.958l1.32 1.02C4.535 11.168 4.5 11.58 4.5 12Zm10.5 0a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z',
   audit: 'M9 5h6m-6 0H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 1 1 6 0M9 12h6m-6 4h4',
+  device: 'M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Zm.75-12h9v9h-9v-9Z',
 };
 
 function iconFor(name: IconName): FunctionalComponent {

--- a/web/src/pages/Projects.vue
+++ b/web/src/pages/Projects.vue
@@ -105,6 +105,13 @@ async function removeProject(p: Project) {
   if (editing.value?.id === p.id) editing.value = null;
 }
 
+// Navigation, not fetch — a Blob would defeat the streaming.
+function exportProject(p: Project, event: Event) {
+  event.stopPropagation();
+  openMenuFor.value = null;
+  window.location.href = `/v1/admin/projects/${p.id}/export`;
+}
+
 function deleteFromMenu(p: Project, event: Event) {
   event.stopPropagation();
   openMenuFor.value = null;
@@ -228,6 +235,11 @@ watch(
               class="block w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800"
               @click="startEdit(p, $event)"
             >Edit project</button>
+            <button
+              type="button"
+              class="block w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800"
+              @click="exportProject(p, $event)"
+            >Export data</button>
             <button
               type="button"
               class="block w-full px-3 py-1.5 text-left text-xs text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"

--- a/web/src/pages/project/DashboardEdit.vue
+++ b/web/src/pages/project/DashboardEdit.vue
@@ -115,6 +115,12 @@ function setViewMode(mode: 'desktop' | 'mobile') {
 }
 
 // Revert the phone layout to the auto-derived arrangement.
+// Empty means the default device, so a dashboard made before devices existed
+// keeps reading what it always did.
+function setDevice(id: string) {
+  layout.value = { ...layout.value, device: id || null };
+}
+
 function resetMobileLayout() {
   if (!layout.value.mobile) return;
   layout.value = { ...layout.value, mobile: null };
@@ -139,6 +145,7 @@ onMounted(async () => {
   }
 
   if (!project.variables.length) await project.loadVariables();
+  if (!project.devices.length) await project.loadDevices();
 
   ws = new DashboardWs(dashId, handleMessage);
   ws.start();
@@ -357,6 +364,15 @@ function exitToView() {
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 lg:hidden"><path d="M3 12a9 9 0 1 0 2.6-6.4L3 8" /><path d="M3 3v5h5" /></svg>
           <span class="hidden lg:inline">Reset layout</span>
         </button>
+        <select
+          v-if="project.devices.length > 1"
+          :value="layout.device ?? ''"
+          class="rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+          title="Which device this dashboard reads"
+          @change="setDevice(($event.target as HTMLSelectElement).value)"
+        >
+          <option v-for="d in project.devices" :key="d.id" :value="d.is_default ? '' : d.id">{{ d.name }}</option>
+        </select>
         <button
           class="rounded-md border border-neutral-300 px-3 py-1.5 text-sm hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
           @click="exitToView"

--- a/web/src/pages/project/automations/AutomationEditor.vue
+++ b/web/src/pages/project/automations/AutomationEditor.vue
@@ -107,6 +107,7 @@ async function init() {
   if (!project.currentProjectId) return;
   await Promise.all([
     project.variables.length ? Promise.resolve() : project.loadVariables(),
+    project.devices.length ? Promise.resolve() : project.loadDevices(),
     project.loadIntegrations(),
   ]);
 

--- a/web/src/pages/project/automations/NodeInspector.vue
+++ b/web/src/pages/project/automations/NodeInspector.vue
@@ -17,6 +17,10 @@ const WEEKDAYS = [
 ];
 
 const variableOptions = computed(() => project.variables.map((v) => ({ value: v.key, label: v.key })));
+const deviceOptions = computed(() => [
+  { value: '', label: 'Any device' },
+  ...project.devices.map((d) => ({ value: d.id, label: d.name })),
+]);
 const integrationOptions = computed(() =>
   project.integrations.map((i) => ({ value: i.id, label: i.name, hint: connSpec(i.kind).label }))
 );
@@ -94,6 +98,14 @@ watch(() => cfg.value['operation'], () => { if (isCallIntegration.value) seedDef
         v-model="cfg[f.key]"
         :options="variableOptions"
         placeholder="Variable"
+        size="sm"
+        class="mt-1 w-full"
+      />
+      <Dropdown
+        v-else-if="f.type === 'device'"
+        v-model="cfg[f.key]"
+        :options="deviceOptions"
+        placeholder="Any device"
         size="sm"
         class="mt-1 w-full"
       />

--- a/web/src/pages/project/device/CodePanel.vue
+++ b/web/src/pages/project/device/CodePanel.vue
@@ -4,6 +4,8 @@ import { api } from '../../../api';
 import { useProjectStore } from '../../../stores/project';
 import { toast } from '../../../lib/toast';
 import CodeEditor from '../../../components/CodeEditor.vue';
+import { useEspFlasher } from '../../../composables/useEspFlasher';
+import { useSerialPort } from '../../../composables/useSerialPort';
 import type { FirmwareCatalog } from '../../../types';
 
 const project = useProjectStore();
@@ -27,6 +29,47 @@ const catalog = ref<FirmwareCatalog>({ tag: null, entries: [] });
 const example = ref('');
 const code = ref('');
 const loading = ref(false);
+
+const FQBNS = [
+  { value: 'esp32:esp32:esp32', label: 'ESP32' },
+  { value: 'esp32:esp32:esp32s3', label: 'ESP32-S3' },
+  { value: 'esp32:esp32:esp32c3', label: 'ESP32-C3' },
+  { value: 'esp8266:esp8266:nodemcuv2', label: 'ESP8266 (NodeMCU)' },
+];
+
+const { flash } = useEspFlasher();
+const { port, request } = useSerialPort();
+const fqbn = ref(FQBNS[0]!.value);
+const building = ref(false);
+const buildLog = ref<string[]>([]);
+const buildError = ref('');
+
+type BuildResult = { ok: boolean; binary?: string; error?: string; log?: string[] };
+
+async function compileAndFlash() {
+  building.value = true;
+  buildLog.value = [];
+  buildError.value = '';
+  try {
+    const res = await api.post<BuildResult>(
+      `/v1/admin/projects/${project.currentProjectId}/build`,
+      { fqbn: fqbn.value, sketch: code.value }
+    );
+    buildLog.value = res.log ?? [];
+    if (!res.ok || !res.binary) {
+      buildError.value = res.error ?? 'Build failed';
+      return;
+    }
+    if (!port.value && !(await request())) return;
+    const bytes = Uint8Array.from(atob(res.binary), (ch) => ch.charCodeAt(0));
+    const ok = await flash([{ data: bytes, address: 0x10000 }]);
+    if (ok) toast.success('Flashed — the board is restarting');
+  } catch (e) {
+    buildError.value = (e as Error).message;
+  } finally {
+    building.value = false;
+  }
+}
 
 // The catalogue lists one binary per chip, so names repeat.
 const examples = computed(() => [...new Set(catalog.value.entries.map((e) => e.example))]);
@@ -115,13 +158,30 @@ function reset() {
 
     <CodeEditor v-model="code" />
 
-    <div class="rounded-xl border border-dashed border-neutral-300 p-4 text-sm dark:border-neutral-700">
-      <p class="font-medium">Compiling needs the nodrix agent</p>
-      <p class="mt-1 text-neutral-600 dark:text-neutral-400">
-        A browser can't run a C++ toolchain — the ESP32 sysroot alone is over 150 MB. The agent runs on
-        your machine, builds with your own Arduino toolchain, and sends the binary back here to flash.
-        Until it's installed, download the sketch and build it in the Arduino IDE.
-      </p>
+    <div class="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <div class="flex flex-wrap items-center gap-2">
+        <select
+          v-model="fqbn"
+          class="rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+        >
+          <option v-for="b in FQBNS" :key="b.value" :value="b.value">{{ b.label }}</option>
+        </select>
+        <button
+          type="button"
+          :disabled="building"
+          class="rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white hover:bg-accent-700 disabled:opacity-50"
+          @click="compileAndFlash"
+        >{{ building ? 'Building…' : 'Compile and flash' }}</button>
+        <p class="text-xs text-neutral-500">
+          Builds on your machine via the nodrix agent. A first build installs the toolchain and takes minutes.
+        </p>
+      </div>
+
+      <p v-if="buildError" class="mt-2 text-xs text-red-600 dark:text-red-400">{{ buildError }}</p>
+      <pre
+        v-if="buildLog.length"
+        class="mt-3 max-h-56 overflow-auto rounded-md bg-neutral-950 p-3 font-mono text-xs text-neutral-300"
+      >{{ buildLog.join('\n') }}</pre>
     </div>
   </div>
 </template>

--- a/web/src/pages/project/device/CodePanel.vue
+++ b/web/src/pages/project/device/CodePanel.vue
@@ -44,24 +44,23 @@ const building = ref(false);
 const buildLog = ref<string[]>([]);
 const buildError = ref('');
 
-type BuildResult = { ok: boolean; binary?: string; error?: string; log?: string[] };
+type BuildResult = { ok: boolean; build?: string; error?: string; log?: string[] };
 
 async function compileAndFlash() {
   building.value = true;
   buildLog.value = [];
   buildError.value = '';
   try {
-    const res = await api.post<BuildResult>(
-      `/v1/admin/projects/${project.currentProjectId}/build`,
-      { fqbn: fqbn.value, sketch: code.value }
-    );
+    const base = `/v1/admin/projects/${project.currentProjectId}/build`;
+    const res = await api.post<BuildResult>(base, { fqbn: fqbn.value, sketch: code.value });
     buildLog.value = res.log ?? [];
-    if (!res.ok || !res.binary) {
+    if (!res.ok || !res.build) {
       buildError.value = res.error ?? 'Build failed';
       return;
     }
     if (!port.value && !(await request())) return;
-    const bytes = Uint8Array.from(atob(res.binary), (ch) => ch.charCodeAt(0));
+    // The image is served once and deleted, so ask for it only after a port is open.
+    const bytes = new Uint8Array(await api.bytes(`${base}/${res.build}/artifact`));
     const ok = await flash([{ data: bytes, address: 0x10000 }]);
     if (ok) toast.success('Flashed — the board is restarting');
   } catch (e) {

--- a/web/src/pages/project/device/CodePanel.vue
+++ b/web/src/pages/project/device/CodePanel.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { api } from '../../../api';
+import { useProjectStore } from '../../../stores/project';
+import { toast } from '../../../lib/toast';
+import CodeEditor from '../../../components/CodeEditor.vue';
+import type { FirmwareCatalog } from '../../../types';
+
+const project = useProjectStore();
+
+const SDK_REPO = 'decoded-cipher/nodrix-sdk';
+const STARTER = `#include <Nodrix.h>
+
+void setup() {
+  Serial.begin(115200);
+  Nodrix.setDebug(true);
+  Nodrix.addAP("your-wifi", "your-password");
+  Nodrix.begin("your-instance.workers.dev", "your-connection-token");
+}
+
+void loop() {
+  Nodrix.run();
+}
+`;
+
+const catalog = ref<FirmwareCatalog>({ tag: null, entries: [] });
+const example = ref('');
+const code = ref('');
+const loading = ref(false);
+
+// The catalogue lists one binary per chip, so names repeat.
+const examples = computed(() => [...new Set(catalog.value.entries.map((e) => e.example))]);
+
+const storageKey = computed(() => `nodrix:sketch:${project.currentProjectId ?? 'none'}`);
+
+onMounted(async () => {
+  code.value = localStorage.getItem(storageKey.value) ?? STARTER;
+  try {
+    catalog.value = await api.get<FirmwareCatalog>('/v1/admin/firmware/catalog');
+  } catch { /* no published release yet */ }
+});
+
+watch(code, (v) => localStorage.setItem(storageKey.value, v));
+
+// Same tag the binaries were built at, so this is what a published image is.
+async function loadExample() {
+  if (!example.value || !catalog.value.tag) return;
+  loading.value = true;
+  try {
+    const url = `https://raw.githubusercontent.com/${SDK_REPO}/${catalog.value.tag}/examples/${example.value}/${example.value}.ino`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Could not load that example');
+    code.value = await res.text();
+  } catch (e) {
+    toast.error((e as Error).message);
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function copy() {
+  await navigator.clipboard.writeText(code.value);
+  toast.success('Sketch copied');
+}
+
+function download() {
+  const blob = new Blob([code.value], { type: 'text/plain' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'sketch.ino';
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+function reset() {
+  code.value = STARTER;
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div class="flex flex-wrap items-center gap-2">
+      <select
+        v-model="example"
+        class="rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+      >
+        <option value="">Load an example…</option>
+        <option v-for="e in examples" :key="e" :value="e">{{ e }}</option>
+      </select>
+      <button
+        type="button"
+        :disabled="!example || loading"
+        class="rounded-md border border-neutral-300 px-2.5 py-1.5 text-xs font-medium hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        @click="loadExample"
+      >{{ loading ? 'Loading…' : 'Load' }}</button>
+
+      <div class="ml-auto flex gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-neutral-300 px-2.5 py-1.5 text-xs font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="copy"
+        >Copy</button>
+        <button
+          type="button"
+          class="rounded-md border border-neutral-300 px-2.5 py-1.5 text-xs font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="download"
+        >Download .ino</button>
+        <button
+          type="button"
+          class="rounded-md border border-neutral-300 px-2.5 py-1.5 text-xs font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="reset"
+        >Reset</button>
+      </div>
+    </div>
+
+    <CodeEditor v-model="code" />
+
+    <div class="rounded-xl border border-dashed border-neutral-300 p-4 text-sm dark:border-neutral-700">
+      <p class="font-medium">Compiling needs the nodrix agent</p>
+      <p class="mt-1 text-neutral-600 dark:text-neutral-400">
+        A browser can't run a C++ toolchain — the ESP32 sysroot alone is over 150 MB. The agent runs on
+        your machine, builds with your own Arduino toolchain, and sends the binary back here to flash.
+        Until it's installed, download the sketch and build it in the Arduino IDE.
+      </p>
+    </div>
+  </div>
+</template>

--- a/web/src/pages/project/device/DeviceHub.vue
+++ b/web/src/pages/project/device/DeviceHub.vue
@@ -10,6 +10,7 @@ const proj = computed(() => project.currentProjectId ?? '');
 
 const tabs = computed(() => [
   { name: 'devices', label: 'Devices', to: `/p/${proj.value}/device`, count: project.devices.length },
+  { name: 'device-code', label: 'Code', to: `/p/${proj.value}/device/code` },
   { name: 'device-flash', label: 'Flash', to: `/p/${proj.value}/device/flash` },
   { name: 'device-firmware', label: 'Firmware', to: `/p/${proj.value}/device/firmware` },
   { name: 'serial-console', label: 'Console', to: `/p/${proj.value}/device/console` },

--- a/web/src/pages/project/device/DeviceHub.vue
+++ b/web/src/pages/project/device/DeviceHub.vue
@@ -9,7 +9,8 @@ const route = useRoute();
 const proj = computed(() => project.currentProjectId ?? '');
 
 const tabs = computed(() => [
-  { name: 'serial-console', label: 'Console', to: `/p/${proj.value}/device` },
+  { name: 'devices', label: 'Devices', to: `/p/${proj.value}/device`, count: project.devices.length },
+  { name: 'serial-console', label: 'Console', to: `/p/${proj.value}/device/console` },
 ]);
 </script>
 
@@ -32,7 +33,13 @@ const tabs = computed(() => [
           :class="route.name === t.name
             ? 'border-accent-600 text-accent-700 dark:text-accent-400'
             : 'border-transparent text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100'"
-        >{{ t.label }}</RouterLink>
+        >
+          {{ t.label }}
+          <span
+            v-if="t.count !== undefined"
+            class="ml-1.5 rounded-full bg-neutral-100 px-1.5 py-0.5 text-[10px] text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
+          >{{ t.count }}</span>
+        </RouterLink>
       </nav>
     </div>
 

--- a/web/src/pages/project/device/DeviceHub.vue
+++ b/web/src/pages/project/device/DeviceHub.vue
@@ -11,6 +11,7 @@ const proj = computed(() => project.currentProjectId ?? '');
 const tabs = computed(() => [
   { name: 'devices', label: 'Devices', to: `/p/${proj.value}/device`, count: project.devices.length },
   { name: 'device-flash', label: 'Flash', to: `/p/${proj.value}/device/flash` },
+  { name: 'device-firmware', label: 'Firmware', to: `/p/${proj.value}/device/firmware` },
   { name: 'serial-console', label: 'Console', to: `/p/${proj.value}/device/console` },
 ]);
 </script>

--- a/web/src/pages/project/device/DeviceHub.vue
+++ b/web/src/pages/project/device/DeviceHub.vue
@@ -10,6 +10,7 @@ const proj = computed(() => project.currentProjectId ?? '');
 
 const tabs = computed(() => [
   { name: 'devices', label: 'Devices', to: `/p/${proj.value}/device`, count: project.devices.length },
+  { name: 'device-flash', label: 'Flash', to: `/p/${proj.value}/device/flash` },
   { name: 'serial-console', label: 'Console', to: `/p/${proj.value}/device/console` },
 ]);
 </script>

--- a/web/src/pages/project/device/DeviceHub.vue
+++ b/web/src/pages/project/device/DeviceHub.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { RouterLink, RouterView, useRoute } from 'vue-router';
+import { useProjectStore } from '../../../stores/project';
+
+const project = useProjectStore();
+const route = useRoute();
+
+const proj = computed(() => project.currentProjectId ?? '');
+
+const tabs = computed(() => [
+  { name: 'serial-console', label: 'Console', to: `/p/${proj.value}/device` },
+]);
+</script>
+
+<template>
+  <div class="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+    <header class="mb-5">
+      <h1 class="text-xl font-semibold tracking-tight">Device</h1>
+      <p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+        Talk to a board over USB — watch what it prints, and see why it isn't connecting.
+      </p>
+    </header>
+
+    <div class="mb-6 border-b border-neutral-200 dark:border-neutral-800">
+      <nav class="-mb-px flex gap-6 text-sm">
+        <RouterLink
+          v-for="t in tabs"
+          :key="t.name"
+          :to="t.to"
+          class="border-b-2 px-1 pb-2.5 font-medium transition"
+          :class="route.name === t.name
+            ? 'border-accent-600 text-accent-700 dark:text-accent-400'
+            : 'border-transparent text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100'"
+        >{{ t.label }}</RouterLink>
+      </nav>
+    </div>
+
+    <RouterView />
+  </div>
+</template>

--- a/web/src/pages/project/device/DevicesList.vue
+++ b/web/src/pages/project/device/DevicesList.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useProjectStore } from '../../../stores/project';
+import { confirm } from '../../../lib/confirm';
+import { toast } from '../../../lib/toast';
+import { relativeTime, formatAbsolute } from '../../../lib/time';
+import Spinner from '../../../components/Spinner.vue';
+
+const project = useProjectStore();
+const loading = ref(true);
+
+onMounted(async () => {
+  try {
+    await project.loadDevices();
+  } catch (e) {
+    toast.error((e as Error).message);
+  } finally {
+    loading.value = false;
+  }
+});
+
+const editingId = ref<string | null>(null);
+const draftName = ref('');
+
+function startEdit(id: string, name: string) {
+  editingId.value = id;
+  draftName.value = name;
+}
+
+// A template ref inside v-for collects into an array, so focus on mount instead.
+function focusName(el: Element | null) {
+  if (el instanceof HTMLInputElement) {
+    el.focus();
+    el.select();
+  }
+}
+
+async function saveName(id: string) {
+  const name = draftName.value.trim();
+  if (!name) return;
+  try {
+    await project.renameDevice(id, name);
+    editingId.value = null;
+  } catch (e) {
+    toast.error((e as Error).message);
+  }
+}
+
+async function forget(id: string, name: string) {
+  const ok = await confirm({
+    title: `Forget ${name}?`,
+    message: 'Its variables and recent history go with it.',
+    details: [
+      'Telemetry already archived is kept.',
+      'The board reappears here if it reports again.',
+    ],
+    confirmLabel: 'Forget',
+  });
+  if (!ok) return;
+  try {
+    await project.forgetDevice(id);
+  } catch (e) {
+    toast.error((e as Error).message);
+  }
+}
+</script>
+
+<template>
+  <div v-if="loading" class="flex justify-center py-10">
+    <Spinner size="sm" label="Loading devices…" />
+  </div>
+
+  <div v-else class="overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-800">
+    <table class="w-full text-sm">
+      <thead class="bg-neutral-50 text-left text-xs uppercase tracking-wide text-neutral-500 dark:bg-neutral-900 dark:text-neutral-400">
+        <tr>
+          <th class="px-4 py-2.5 font-medium">Name</th>
+          <th class="px-4 py-2.5 font-medium">Chip</th>
+          <th class="px-4 py-2.5 font-medium">Firmware</th>
+          <th class="px-4 py-2.5 font-medium">Last seen</th>
+          <th class="px-4 py-2.5" />
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-neutral-200 dark:divide-neutral-800">
+        <tr v-for="d in project.devices" :key="d.id">
+          <td class="px-4 py-2.5">
+            <input
+              v-if="editingId === d.id"
+              :ref="(el) => focusName(el as Element | null)"
+              v-model="draftName"
+              class="w-full rounded-md border border-neutral-300 bg-white px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+              @keyup.enter="saveName(d.id)"
+              @keyup.esc="editingId = null"
+              @blur="saveName(d.id)"
+            />
+            <span v-else class="font-medium">{{ d.name }}</span>
+            <span
+              v-if="d.is_default && editingId !== d.id"
+              class="ml-2 rounded-full bg-neutral-100 px-1.5 py-0.5 text-[10px] text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
+            >default</span>
+          </td>
+          <td class="px-4 py-2.5 text-neutral-600 dark:text-neutral-400">{{ d.chip ?? '—' }}</td>
+          <td class="px-4 py-2.5 text-neutral-600 dark:text-neutral-400">{{ d.firmware_version ?? '—' }}</td>
+          <td class="px-4 py-2.5 text-neutral-600 dark:text-neutral-400" :title="d.last_seen ? formatAbsolute(d.last_seen) : ''">
+            {{ d.last_seen ? relativeTime(d.last_seen) : 'Never' }}
+          </td>
+          <td class="px-4 py-2.5 text-right">
+            <button
+              type="button"
+              class="text-xs font-medium text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
+              @click="startEdit(d.id, d.name)"
+            >Rename</button>
+            <button
+              v-if="!d.is_default"
+              type="button"
+              class="ml-3 text-xs font-medium text-red-600 hover:text-red-700 dark:text-red-400"
+              @click="forget(d.id, d.name)"
+            >Forget</button>
+          </td>
+        </tr>
+        <tr v-if="!project.devices.length">
+          <td colspan="5" class="px-4 py-8 text-center text-sm text-neutral-500">
+            No devices yet. A board appears here the first time it reports.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/web/src/pages/project/device/DevicesList.vue
+++ b/web/src/pages/project/device/DevicesList.vue
@@ -27,6 +27,13 @@ function startEdit(id: string, name: string) {
   draftName.value = name;
 }
 
+// Derived: a device that stops reporting never writes, so no stored flag would flip.
+const OFFLINE_AFTER_SECONDS = 5 * 60;
+
+function online(lastSeen: number | null): boolean {
+  return !!lastSeen && Math.floor(Date.now() / 1000) - lastSeen < OFFLINE_AFTER_SECONDS;
+}
+
 // A template ref inside v-for collects into an array, so focus on mount instead.
 function focusName(el: Element | null) {
   if (el instanceof HTMLInputElement) {
@@ -93,7 +100,14 @@ async function forget(id: string, name: string) {
               @keyup.esc="editingId = null"
               @blur="saveName(d.id)"
             />
-            <span v-else class="font-medium">{{ d.name }}</span>
+            <span v-else class="inline-flex items-center gap-2 font-medium">
+              <span
+                class="h-1.5 w-1.5 shrink-0 rounded-full"
+                :class="online(d.last_seen) ? 'bg-emerald-500' : 'bg-neutral-300 dark:bg-neutral-600'"
+                :title="online(d.last_seen) ? 'Reporting' : 'Not reporting'"
+              />
+              {{ d.name }}
+            </span>
             <span
               v-if="d.is_default && editingId !== d.id"
               class="ml-2 rounded-full bg-neutral-100 px-1.5 py-0.5 text-[10px] text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"

--- a/web/src/pages/project/device/FirmwarePanel.vue
+++ b/web/src/pages/project/device/FirmwarePanel.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useProjectStore } from '../../../stores/project';
+import { confirm } from '../../../lib/confirm';
+import { toast } from '../../../lib/toast';
+import { relativeTime } from '../../../lib/time';
+import Spinner from '../../../components/Spinner.vue';
+
+const project = useProjectStore();
+const loading = ref(true);
+
+const version = ref('');
+const notes = ref('');
+const file = ref<File | null>(null);
+const uploading = ref(false);
+
+onMounted(async () => {
+  try {
+    await Promise.all([project.loadFirmware(), project.loadDevices()]);
+  } catch (e) {
+    toast.error((e as Error).message);
+  } finally {
+    loading.value = false;
+  }
+});
+
+function pick(e: Event) {
+  file.value = (e.target as HTMLInputElement).files?.[0] ?? null;
+}
+
+async function upload() {
+  if (!file.value || !version.value.trim()) return;
+  uploading.value = true;
+  try {
+    await project.uploadFirmware({
+      version: version.value.trim(),
+      notes: notes.value.trim() || undefined,
+      body: await file.value.arrayBuffer(),
+    });
+    version.value = '';
+    notes.value = '';
+    file.value = null;
+    toast.success('Firmware uploaded');
+  } catch (e) {
+    toast.error((e as Error).message);
+  } finally {
+    uploading.value = false;
+  }
+}
+
+async function remove(id: string, v: string) {
+  const ok = await confirm({
+    title: `Delete ${v}?`,
+    message: 'Any device set to update to it goes back to having nothing pending.',
+    confirmLabel: 'Delete',
+  });
+  if (!ok) return;
+  try {
+    await project.deleteFirmware(id);
+  } catch (e) {
+    toast.error((e as Error).message);
+  }
+}
+
+async function assign(deviceId: string, firmwareId: string) {
+  try {
+    await project.assignFirmware(deviceId, firmwareId || null);
+  } catch (e) {
+    toast.error((e as Error).message);
+  }
+}
+
+function sizeKb(bytes: number) {
+  return `${Math.round(bytes / 1024)} KB`;
+}
+
+function statusOf(d: { desired_firmware_id: string | null; ota_status: string | null; firmware_version: string | null }) {
+  if (!d.desired_firmware_id) return d.firmware_version ?? 'unknown';
+  if (d.ota_status === 'ok') return d.firmware_version ?? 'up to date';
+  return 'waiting for the device';
+}
+</script>
+
+<template>
+  <div v-if="loading" class="flex justify-center py-10">
+    <Spinner size="sm" label="Loading firmware…" />
+  </div>
+
+  <div v-else class="space-y-6">
+    <div class="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <h2 class="text-sm font-semibold">Upload an image</h2>
+      <div class="mt-3 grid gap-3 sm:grid-cols-[10rem_1fr]">
+        <label class="block">
+          <span class="block text-xs font-medium text-neutral-600 dark:text-neutral-300">Version</span>
+          <input
+            v-model="version"
+            placeholder="1.4.0"
+            class="mt-1 w-full rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+          />
+        </label>
+        <label class="block">
+          <span class="block text-xs font-medium text-neutral-600 dark:text-neutral-300">Notes</span>
+          <input
+            v-model="notes"
+            placeholder="What changed"
+            class="mt-1 w-full rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+          />
+        </label>
+      </div>
+      <input
+        type="file"
+        accept=".bin"
+        class="mt-3 block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-neutral-100 file:px-3 file:py-1.5 file:text-sm file:font-medium dark:file:bg-neutral-800 dark:file:text-neutral-200"
+        @change="pick"
+      />
+      <button
+        type="button"
+        :disabled="!file || !version.trim() || uploading"
+        class="mt-3 rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white hover:bg-accent-700 disabled:opacity-50"
+        @click="upload"
+      >{{ uploading ? 'Uploading…' : 'Upload' }}</button>
+      <p class="mt-2 text-xs text-neutral-500">
+        The version must match what the sketch reports, or the device will never be marked updated.
+      </p>
+    </div>
+
+    <div>
+      <h2 class="mb-2 text-sm font-semibold">Images</h2>
+      <div class="overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-800">
+        <table class="w-full text-sm">
+          <tbody class="divide-y divide-neutral-200 dark:divide-neutral-800">
+            <tr v-for="f in project.firmware" :key="f.id">
+              <td class="px-4 py-2.5 font-medium">{{ f.version }}</td>
+              <td class="px-4 py-2.5 text-neutral-600 dark:text-neutral-400">{{ sizeKb(f.size) }}</td>
+              <td class="px-4 py-2.5 text-neutral-600 dark:text-neutral-400">{{ f.notes ?? '—' }}</td>
+              <td class="px-4 py-2.5 text-neutral-500">{{ relativeTime(f.created_at) }}</td>
+              <td class="px-4 py-2.5 text-right">
+                <button
+                  type="button"
+                  class="text-xs font-medium text-red-600 hover:text-red-700 dark:text-red-400"
+                  @click="remove(f.id, f.version)"
+                >Delete</button>
+              </td>
+            </tr>
+            <tr v-if="!project.firmware.length">
+              <td colspan="5" class="px-4 py-8 text-center text-sm text-neutral-500">
+                No images yet. Upload one to update devices over the air.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="mb-2 text-sm font-semibold">Devices</h2>
+      <div class="overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-800">
+        <table class="w-full text-sm">
+          <thead class="bg-neutral-50 text-left text-xs uppercase tracking-wide text-neutral-500 dark:bg-neutral-900 dark:text-neutral-400">
+            <tr>
+              <th class="px-4 py-2.5 font-medium">Device</th>
+              <th class="px-4 py-2.5 font-medium">Running</th>
+              <th class="px-4 py-2.5 font-medium">Should run</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-200 dark:divide-neutral-800">
+            <tr v-for="d in project.devices" :key="d.id">
+              <td class="px-4 py-2.5 font-medium">{{ d.name }}</td>
+              <td class="px-4 py-2.5 text-neutral-600 dark:text-neutral-400">{{ statusOf(d) }}</td>
+              <td class="px-4 py-2.5">
+                <select
+                  :value="d.desired_firmware_id ?? ''"
+                  class="w-full max-w-[14rem] rounded-md border border-neutral-300 bg-white px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  @change="assign(d.id, ($event.target as HTMLSelectElement).value)"
+                >
+                  <option value="">Nothing pending</option>
+                  <option v-for="f in project.firmware" :key="f.id" :value="f.id">{{ f.version }}</option>
+                </select>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="mt-2 text-xs text-neutral-500">
+        Devices pull on their own schedule. A connected board is nudged to check immediately.
+      </p>
+    </div>
+  </div>
+</template>

--- a/web/src/pages/project/device/FlashPanel.vue
+++ b/web/src/pages/project/device/FlashPanel.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useSerialPort } from '../../../composables/useSerialPort';
+import { useEspFlasher, type FlashPart } from '../../../composables/useEspFlasher';
+import { toast } from '../../../lib/toast';
+
+const { supported, port, request } = useSerialPort();
+const { flash, phase, progress, chip, error } = useEspFlasher();
+
+// A sketch built by Arduino starts here; a full factory image starts at 0.
+const DEFAULT_OFFSET = 0x10000;
+
+const file = ref<File | null>(null);
+const offset = ref(DEFAULT_OFFSET);
+
+const busy = computed(() => phase.value === 'connecting' || phase.value === 'writing');
+const offsetHex = computed({
+  get: () => `0x${offset.value.toString(16)}`,
+  set: (v: string) => {
+    const n = Number.parseInt(v.replace(/^0x/i, ''), 16);
+    if (Number.isFinite(n) && n >= 0) offset.value = n;
+  },
+});
+
+function pick(e: Event) {
+  const input = e.target as HTMLInputElement;
+  file.value = input.files?.[0] ?? null;
+}
+
+async function start() {
+  if (!file.value) return;
+  if (!port.value && !(await request())) return;
+  const parts: FlashPart[] = [
+    { data: new Uint8Array(await file.value.arrayBuffer()), address: offset.value },
+  ];
+  const ok = await flash(parts);
+  if (ok) toast.success('Flashed — the board is restarting');
+  else toast.error(error.value ?? 'Flashing failed');
+}
+</script>
+
+<template>
+  <div v-if="!supported" class="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+    <h2 class="text-sm font-semibold">This browser can't flash boards</h2>
+    <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+      Flashing needs the Web Serial API — Chrome, Edge or Opera on desktop, or Chrome on Android, over
+      HTTPS. You can still flash from a terminal:
+    </p>
+    <pre class="mt-3 overflow-x-auto rounded-md bg-neutral-950 p-3 font-mono text-xs text-neutral-300"
+>esptool.py --chip auto --port /dev/ttyUSB0 write_flash 0x10000 firmware.bin</pre>
+  </div>
+
+  <div v-else class="space-y-4">
+    <div class="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <label class="block">
+        <span class="block text-xs font-medium text-neutral-600 dark:text-neutral-300">Firmware</span>
+        <input
+          type="file"
+          accept=".bin"
+          class="mt-1 block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-neutral-100 file:px-3 file:py-1.5 file:text-sm file:font-medium dark:file:bg-neutral-800 dark:file:text-neutral-200"
+          @change="pick"
+        />
+      </label>
+
+      <label class="mt-3 block max-w-[12rem]">
+        <span class="block text-xs font-medium text-neutral-600 dark:text-neutral-300">Flash offset</span>
+        <input
+          v-model="offsetHex"
+          class="mt-1 w-full rounded-md border border-neutral-300 bg-white px-2 py-1 font-mono text-sm dark:border-neutral-700 dark:bg-neutral-950"
+        />
+        <span class="mt-1 block text-[11px] text-neutral-500">
+          0x10000 for an Arduino sketch, 0x0 for a full image.
+        </span>
+      </label>
+
+      <button
+        type="button"
+        :disabled="!file || busy"
+        class="mt-4 rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white hover:bg-accent-700 disabled:opacity-50"
+        @click="start"
+      >{{ busy ? 'Flashing…' : 'Flash' }}</button>
+
+      <p class="mt-2 text-xs text-neutral-500">
+        The console disconnects while flashing and reconnects when it finishes.
+      </p>
+    </div>
+
+    <div v-if="phase !== 'idle'" class="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <div class="flex items-center justify-between text-sm">
+        <span class="font-medium">
+          {{ phase === 'connecting' ? 'Connecting to the board…'
+            : phase === 'writing' ? 'Writing'
+            : phase === 'done' ? 'Done' : 'Failed' }}
+        </span>
+        <span v-if="chip" class="text-xs text-neutral-500">{{ chip }}</span>
+      </div>
+      <div v-if="phase === 'writing'" class="mt-2 h-1.5 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800">
+        <div class="h-full bg-accent-600 transition-[width]" :style="{ width: `${Math.round(progress * 100)}%` }" />
+      </div>
+      <p v-if="error" class="mt-2 text-xs text-red-600 dark:text-red-400">{{ error }}</p>
+    </div>
+  </div>
+</template>

--- a/web/src/pages/project/device/FlashPanel.vue
+++ b/web/src/pages/project/device/FlashPanel.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
+import { api } from '../../../api';
 import { useSerialPort } from '../../../composables/useSerialPort';
 import { useEspFlasher, type FlashPart } from '../../../composables/useEspFlasher';
 import { toast } from '../../../lib/toast';
+import type { FirmwareCatalog } from '../../../types';
 
 const { supported, port, request } = useSerialPort();
 const { flash, phase, progress, chip, error } = useEspFlasher();
@@ -10,8 +12,31 @@ const { flash, phase, progress, chip, error } = useEspFlasher();
 // A sketch built by Arduino starts here; a full factory image starts at 0.
 const DEFAULT_OFFSET = 0x10000;
 
+const source = ref<'example' | 'file'>('example');
+const catalog = ref<FirmwareCatalog>({ tag: null, entries: [] });
+const selected = ref('');
 const file = ref<File | null>(null);
 const offset = ref(DEFAULT_OFFSET);
+
+onMounted(async () => {
+  try {
+    catalog.value = await api.get<FirmwareCatalog>('/v1/admin/firmware/catalog');
+    selected.value = catalog.value.entries[0]?.file ?? '';
+  } catch { /* no published examples is a normal state */ }
+  if (!catalog.value.entries.length) source.value = 'file';
+});
+
+const ready = computed(() => (source.value === 'example' ? !!selected.value : !!file.value));
+
+async function loadBytes(): Promise<Uint8Array> {
+  if (source.value === 'file') return new Uint8Array(await file.value!.arrayBuffer());
+  const res = await fetch(
+    `/v1/admin/firmware/binary/${encodeURIComponent(catalog.value.tag ?? '')}/${encodeURIComponent(selected.value)}`,
+    { credentials: 'include' }
+  );
+  if (!res.ok) throw new Error('Could not download that firmware');
+  return new Uint8Array(await res.arrayBuffer());
+}
 
 const busy = computed(() => phase.value === 'connecting' || phase.value === 'writing');
 const offsetHex = computed({
@@ -28,11 +53,15 @@ function pick(e: Event) {
 }
 
 async function start() {
-  if (!file.value) return;
+  if (!ready.value) return;
   if (!port.value && !(await request())) return;
-  const parts: FlashPart[] = [
-    { data: new Uint8Array(await file.value.arrayBuffer()), address: offset.value },
-  ];
+  let parts: FlashPart[];
+  try {
+    parts = [{ data: await loadBytes(), address: offset.value }];
+  } catch (e) {
+    toast.error((e as Error).message);
+    return;
+  }
   const ok = await flash(parts);
   if (ok) toast.success('Flashed — the board is restarting');
   else toast.error(error.value ?? 'Flashing failed');
@@ -52,7 +81,33 @@ async function start() {
 
   <div v-else class="space-y-4">
     <div class="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
-      <label class="block">
+      <div class="mb-3 flex gap-4 text-xs">
+        <label class="flex items-center gap-1.5">
+          <input v-model="source" type="radio" value="example" :disabled="!catalog.entries.length" />
+          Published example
+        </label>
+        <label class="flex items-center gap-1.5">
+          <input v-model="source" type="radio" value="file" />
+          My own .bin
+        </label>
+      </div>
+
+      <label v-if="source === 'example'" class="block">
+        <span class="block text-xs font-medium text-neutral-600 dark:text-neutral-300">Example</span>
+        <select
+          v-model="selected"
+          class="mt-1 w-full rounded-md border border-neutral-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+        >
+          <option v-for="e in catalog.entries" :key="e.file" :value="e.file">
+            {{ e.example }} — {{ e.target }}
+          </option>
+        </select>
+        <span class="mt-1 block text-[11px] text-neutral-500">
+          Built from the SDK examples at {{ catalog.tag }}.
+        </span>
+      </label>
+
+      <label v-else class="block">
         <span class="block text-xs font-medium text-neutral-600 dark:text-neutral-300">Firmware</span>
         <input
           type="file"
@@ -75,7 +130,7 @@ async function start() {
 
       <button
         type="button"
-        :disabled="!file || busy"
+        :disabled="!ready || busy"
         class="mt-4 rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white hover:bg-accent-700 disabled:opacity-50"
         @click="start"
       >{{ busy ? 'Flashing…' : 'Flash' }}</button>

--- a/web/src/pages/project/device/SerialConsole.vue
+++ b/web/src/pages/project/device/SerialConsole.vue
@@ -2,10 +2,12 @@
 import { computed, nextTick, ref, watch } from 'vue';
 import { useSerialPort, BAUD_RATES } from '../../../composables/useSerialPort';
 import { useSerialLog, type LogEntry } from '../../../composables/useSerialLog';
+import { useSerialDiagnosis } from '../../../composables/useSerialDiagnosis';
 import { toast } from '../../../lib/toast';
 
 const { supported, port, state, lastError, request, startMonitor, stopMonitor, setBaud } = useSerialPort();
 const { entries, paused, garbled, setPaused, clear, toText } = useSerialLog();
+const diagnosis = useSerialDiagnosis();
 
 const viewport = ref<HTMLElement | null>(null);
 const stuckToBottom = ref(true);
@@ -54,6 +56,12 @@ async function copyAll() {
 }
 
 // The viewport is dark in both themes, so these take no light variant.
+const DIAGNOSIS_TONE = {
+  ok: 'border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200',
+  warn: 'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200',
+  error: 'border-red-300 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200',
+};
+
 const TONE: Record<LogEntry['level'], string> = {
   ok: 'text-emerald-400',
   warn: 'text-amber-400',
@@ -117,6 +125,11 @@ function stamp(at: number) {
           @click="clear()"
         >Clear</button>
       </div>
+    </div>
+
+    <div v-if="diagnosis" class="rounded-lg border px-3 py-2" :class="DIAGNOSIS_TONE[diagnosis.tone]">
+      <p class="text-sm font-semibold">{{ diagnosis.headline }}</p>
+      <p v-if="diagnosis.detail" class="mt-0.5 text-xs opacity-90">{{ diagnosis.detail }}</p>
     </div>
 
     <p v-if="garbled" class="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">

--- a/web/src/pages/project/device/SerialConsole.vue
+++ b/web/src/pages/project/device/SerialConsole.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue';
+import { useSerialPort, BAUD_RATES } from '../../../composables/useSerialPort';
+import { useSerialLog, type LogEntry } from '../../../composables/useSerialLog';
+import { toast } from '../../../lib/toast';
+
+const { supported, port, state, lastError, request, startMonitor, stopMonitor, setBaud } = useSerialPort();
+const { entries, paused, garbled, setPaused, clear, toText } = useSerialLog();
+
+const viewport = ref<HTMLElement | null>(null);
+const stuckToBottom = ref(true);
+const baud = ref(115200);
+
+const connected = computed(() => state.value === 'open');
+const busy = computed(() => state.value === 'opening' || state.value === 'busy');
+
+function onScroll() {
+  const el = viewport.value;
+  if (!el) return;
+  stuckToBottom.value = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+}
+
+watch(entries, async () => {
+  if (!stuckToBottom.value) return;
+  await nextTick();
+  const el = viewport.value;
+  if (el) el.scrollTop = el.scrollHeight;
+});
+
+async function connect() {
+  if (!port.value && !(await request())) return;
+  try {
+    await startMonitor(baud.value);
+  } catch (e) {
+    toast.error((e as Error).message);
+  }
+}
+
+async function disconnect() {
+  await stopMonitor();
+}
+
+async function changeBaud() {
+  try {
+    await setBaud(baud.value);
+  } catch (e) {
+    toast.error((e as Error).message);
+  }
+}
+
+async function copyAll() {
+  await navigator.clipboard.writeText(toText());
+  toast.success('Console copied');
+}
+
+// The viewport is dark in both themes, so these take no light variant.
+const TONE: Record<LogEntry['level'], string> = {
+  ok: 'text-emerald-400',
+  warn: 'text-amber-400',
+  error: 'text-red-400',
+  system: 'text-neutral-500 italic',
+  info: 'text-neutral-300',
+};
+
+function stamp(at: number) {
+  return new Date(at).toTimeString().slice(0, 8);
+}
+</script>
+
+<template>
+  <div v-if="!supported" class="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+    <h2 class="text-sm font-semibold">This browser can't talk to serial devices</h2>
+    <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+      The console uses the Web Serial API, which needs Chrome, Edge or Opera on desktop, or Chrome on
+      Android. Safari and Firefox don't support it. It also needs a secure (HTTPS) connection.
+    </p>
+    <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+      Everything else in nodrix works here — this page is the only part that needs direct USB access.
+    </p>
+  </div>
+
+  <div v-else class="space-y-3">
+    <div class="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        :disabled="busy"
+        class="rounded-md px-3 py-1.5 text-sm font-semibold text-white disabled:opacity-50"
+        :class="connected ? 'bg-neutral-700 hover:bg-neutral-800' : 'bg-accent-600 hover:bg-accent-700'"
+        @click="connected ? disconnect() : connect()"
+      >{{ connected ? 'Disconnect' : busy ? 'Connecting…' : 'Connect' }}</button>
+
+      <label class="flex items-center gap-1.5 text-xs text-neutral-600 dark:text-neutral-400">
+        Baud
+        <select
+          v-model.number="baud"
+          class="rounded-md border border-neutral-300 bg-white px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100"
+          @change="changeBaud"
+        >
+          <option v-for="b in BAUD_RATES" :key="b" :value="b">{{ b }}</option>
+        </select>
+      </label>
+
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-neutral-300 px-2.5 py-1.5 text-xs font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="setPaused(!paused)"
+        >{{ paused ? 'Resume' : 'Pause' }}</button>
+        <button
+          type="button"
+          class="rounded-md border border-neutral-300 px-2.5 py-1.5 text-xs font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="copyAll"
+        >Copy</button>
+        <button
+          type="button"
+          class="rounded-md border border-neutral-300 px-2.5 py-1.5 text-xs font-medium hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="clear()"
+        >Clear</button>
+      </div>
+    </div>
+
+    <p v-if="garbled" class="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+      This looks like the wrong baud rate. Most nodrix sketches use 115200.
+    </p>
+
+    <p v-if="lastError" class="text-xs text-red-600 dark:text-red-400">{{ lastError }}</p>
+
+    <div
+      ref="viewport"
+      class="h-[26rem] overflow-y-auto rounded-xl border border-neutral-200 bg-neutral-950 p-3 font-mono text-xs leading-relaxed dark:border-neutral-800"
+      @scroll="onScroll"
+    >
+      <p v-if="!entries.length" class="text-neutral-500">
+        Connect a board to see what it's printing. Call <code>Nodrix.setDebug(true)</code> in your sketch
+        for connection details.
+      </p>
+      <div v-for="e in entries" :key="e.id" class="flex gap-2 whitespace-pre-wrap break-all">
+        <span class="shrink-0 text-neutral-500 tabular-nums">{{ stamp(e.at) }}</span>
+        <span v-if="e.tag" class="shrink-0 text-neutral-500">{{ e.tag }}</span>
+        <span :class="TONE[e.level]">{{ e.text }}</span>
+      </div>
+    </div>
+
+    <p v-if="!stuckToBottom" class="text-xs text-neutral-500">Scrolled up — new lines aren't following.</p>
+  </div>
+</template>

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -48,6 +48,7 @@ const routes: RouteRecordRaw[] = [
             component: () => import('./pages/project/device/DeviceHub.vue'),
             children: [
               { path: '', name: 'devices', component: () => import('./pages/project/device/DevicesList.vue'), meta: { title: 'Devices' } },
+              { path: 'firmware', name: 'device-firmware', component: () => import('./pages/project/device/FirmwarePanel.vue'), meta: { title: 'Firmware' } },
               { path: 'flash', name: 'device-flash', component: () => import('./pages/project/device/FlashPanel.vue'), meta: { title: 'Flash' } },
               { path: 'console', name: 'serial-console', component: () => import('./pages/project/device/SerialConsole.vue'), meta: { title: 'Console' } },
             ],

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -43,6 +43,13 @@ const routes: RouteRecordRaw[] = [
               { path: 'tokens', name: 'variable-tokens', component: () => import('./pages/project/variables/ConnectionTokens.vue'), meta: { title: 'Connection tokens' } },
             ],
           },
+          {
+            path: 'device',
+            component: () => import('./pages/project/device/DeviceHub.vue'),
+            children: [
+              { path: '', name: 'serial-console', component: () => import('./pages/project/device/SerialConsole.vue'), meta: { title: 'Console' } },
+            ],
+          },
           // Automations + Integrations live under one hub with two tabs.
           {
             path: 'automations',

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -49,6 +49,7 @@ const routes: RouteRecordRaw[] = [
             children: [
               { path: '', name: 'devices', component: () => import('./pages/project/device/DevicesList.vue'), meta: { title: 'Devices' } },
               { path: 'firmware', name: 'device-firmware', component: () => import('./pages/project/device/FirmwarePanel.vue'), meta: { title: 'Firmware' } },
+              { path: 'code', name: 'device-code', component: () => import('./pages/project/device/CodePanel.vue'), meta: { title: 'Code' } },
               { path: 'flash', name: 'device-flash', component: () => import('./pages/project/device/FlashPanel.vue'), meta: { title: 'Flash' } },
               { path: 'console', name: 'serial-console', component: () => import('./pages/project/device/SerialConsole.vue'), meta: { title: 'Console' } },
             ],

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -48,6 +48,7 @@ const routes: RouteRecordRaw[] = [
             component: () => import('./pages/project/device/DeviceHub.vue'),
             children: [
               { path: '', name: 'devices', component: () => import('./pages/project/device/DevicesList.vue'), meta: { title: 'Devices' } },
+              { path: 'flash', name: 'device-flash', component: () => import('./pages/project/device/FlashPanel.vue'), meta: { title: 'Flash' } },
               { path: 'console', name: 'serial-console', component: () => import('./pages/project/device/SerialConsole.vue'), meta: { title: 'Console' } },
             ],
           },

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -47,7 +47,8 @@ const routes: RouteRecordRaw[] = [
             path: 'device',
             component: () => import('./pages/project/device/DeviceHub.vue'),
             children: [
-              { path: '', name: 'serial-console', component: () => import('./pages/project/device/SerialConsole.vue'), meta: { title: 'Console' } },
+              { path: '', name: 'devices', component: () => import('./pages/project/device/DevicesList.vue'), meta: { title: 'Devices' } },
+              { path: 'console', name: 'serial-console', component: () => import('./pages/project/device/SerialConsole.vue'), meta: { title: 'Console' } },
             ],
           },
           // Automations + Integrations live under one hub with two tabs.

--- a/web/src/stores/project.ts
+++ b/web/src/stores/project.ts
@@ -8,6 +8,7 @@ import type {
   AutomationGraph,
   Dashboard,
   DashboardMeta,
+  Device,
   Variable,
   ProjectToken,
   ProjectTokenWithSecret,
@@ -23,6 +24,7 @@ export const useProjectStore = defineStore('project', () => {
   const currentProjectId = ref<string | null>(null);
   const variables = ref<Variable[]>([]);
   const projectTokens = ref<ProjectToken[]>([]);
+  const devices = ref<Device[]>([]);
   const dashboards = ref<DashboardMeta[]>([]);
   const tokens = ref<UserToken[]>([]);
   const automations = ref<Automation[]>([]);
@@ -42,6 +44,7 @@ export const useProjectStore = defineStore('project', () => {
       automations.value = [];
       integrations.value = [];
       projectTokens.value = [];
+      devices.value = [];
     }
     currentProjectId.value = projectId;
     await Promise.all([loadVariables(), loadDashboards()]);
@@ -62,6 +65,31 @@ export const useProjectStore = defineStore('project', () => {
       `/v1/admin/projects/${currentProjectId.value}/variables`
     );
     variables.value = data.variables;
+  }
+
+  async function loadDevices(): Promise<void> {
+    if (!currentProjectId.value) return;
+    const data = await api.get<{ devices: Device[] }>(
+      `/v1/admin/projects/${currentProjectId.value}/devices`
+    );
+    devices.value = data.devices;
+  }
+
+  async function renameDevice(id: string, name: string): Promise<void> {
+    const pid = requireProjectId();
+    const { device } = await api.patch<{ device: Device }>(
+      `/v1/admin/projects/${pid}/devices/${id}`,
+      { name }
+    );
+    devices.value = devices.value.map((d) => (d.id === id ? device : d));
+  }
+
+  async function forgetDevice(id: string): Promise<void> {
+    const pid = requireProjectId();
+    await api.del(`/v1/admin/projects/${pid}/devices/${id}`);
+    devices.value = devices.value.filter((d) => d.id !== id);
+    // Its variables went with it.
+    await loadVariables();
   }
 
   async function createVariable(input: { key: string; unit?: string | null }): Promise<Variable> {
@@ -370,6 +398,7 @@ export const useProjectStore = defineStore('project', () => {
   return {
     currentProjectId,
     variables,
+    devices,
     projectTokens,
     dashboards,
     tokens,
@@ -377,6 +406,9 @@ export const useProjectStore = defineStore('project', () => {
     integrations,
     pendingAutomation,
     switchTo,
+    loadDevices,
+    renameDevice,
+    forgetDevice,
     loadVariables,
     createVariable,
     updateVariable,

--- a/web/src/stores/project.ts
+++ b/web/src/stores/project.ts
@@ -9,6 +9,7 @@ import type {
   Dashboard,
   DashboardMeta,
   Device,
+  Firmware,
   Variable,
   ProjectToken,
   ProjectTokenWithSecret,
@@ -25,6 +26,7 @@ export const useProjectStore = defineStore('project', () => {
   const variables = ref<Variable[]>([]);
   const projectTokens = ref<ProjectToken[]>([]);
   const devices = ref<Device[]>([]);
+  const firmware = ref<Firmware[]>([]);
   const dashboards = ref<DashboardMeta[]>([]);
   const tokens = ref<UserToken[]>([]);
   const automations = ref<Automation[]>([]);
@@ -45,6 +47,7 @@ export const useProjectStore = defineStore('project', () => {
       integrations.value = [];
       projectTokens.value = [];
       devices.value = [];
+      firmware.value = [];
     }
     currentProjectId.value = projectId;
     await Promise.all([loadVariables(), loadDashboards()]);
@@ -73,6 +76,46 @@ export const useProjectStore = defineStore('project', () => {
       `/v1/admin/projects/${currentProjectId.value}/devices`
     );
     devices.value = data.devices;
+  }
+
+  async function loadFirmware(): Promise<void> {
+    if (!currentProjectId.value) return;
+    const data = await api.get<{ firmware: Firmware[] }>(
+      `/v1/admin/projects/${currentProjectId.value}/firmware`
+    );
+    firmware.value = data.firmware;
+  }
+
+  async function uploadFirmware(input: { version: string; target?: string; notes?: string; body: ArrayBuffer }): Promise<void> {
+    const pid = requireProjectId();
+    const q = new URLSearchParams({ version: input.version });
+    if (input.target) q.set('target', input.target);
+    if (input.notes) q.set('notes', input.notes);
+    // Raw body, so this bypasses the JSON api helper.
+    const res = await fetch(`/v1/admin/projects/${pid}/firmware?${q}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: input.body,
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({})) as { error?: string };
+      throw new Error(err.error ?? `Upload failed (${res.status})`);
+    }
+    await loadFirmware();
+  }
+
+  async function deleteFirmware(id: string): Promise<void> {
+    const pid = requireProjectId();
+    await api.del(`/v1/admin/projects/${pid}/firmware/${id}`);
+    firmware.value = firmware.value.filter((f) => f.id !== id);
+    await loadDevices();
+  }
+
+  async function assignFirmware(deviceId: string, firmwareId: string | null): Promise<void> {
+    const pid = requireProjectId();
+    await api.put(`/v1/admin/projects/${pid}/firmware/assign/${deviceId}`, { firmware_id: firmwareId });
+    await loadDevices();
   }
 
   async function renameDevice(id: string, name: string): Promise<void> {
@@ -399,6 +442,7 @@ export const useProjectStore = defineStore('project', () => {
     currentProjectId,
     variables,
     devices,
+    firmware,
     projectTokens,
     dashboards,
     tokens,
@@ -407,6 +451,10 @@ export const useProjectStore = defineStore('project', () => {
     pendingAutomation,
     switchTo,
     loadDevices,
+    loadFirmware,
+    uploadFirmware,
+    deleteFirmware,
+    assignFirmware,
     renameDevice,
     forgetDevice,
     loadVariables,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -136,6 +136,8 @@ export type MobilePlacement = { id: string; x: number; y: number; w: number; h: 
 export type Layout = {
   grid: { columns: number };
   items: WidgetInstance[];
+  // Which device the widgets' variable keys belong to. Absent => the default.
+  device?: string | null;
   // Phone layout override, nested in the same layout JSON (no separate column).
   // Absent/null => auto-derive the phone layout from the desktop items.
   mobile?: { items: MobilePlacement[] } | null;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -80,6 +80,9 @@ export type Device = {
   last_seen: number | null;
 };
 
+export type FirmwareEntry = { example: string; target: string; file: string; size: number };
+export type FirmwareCatalog = { tag: string | null; entries: FirmwareEntry[] };
+
 export type ProjectToken = {
   id: string;
   name?: string | null;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -187,6 +187,7 @@ export type VariableOperator = '>' | '<' | '>=' | '<=' | '==' | '!=' | 'changed'
 
 export type VariableTriggerConfig = {
   variable: string;                   // variable key
+  device?: string | null;             // device id; absent/empty = any device
   operator: VariableOperator;
   value?: number | string | boolean;  // omitted for 'changed'
   mode?: 'edge' | 'always';           // edge = fire once on entry (default)

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -78,6 +78,18 @@ export type Device = {
   is_default: number;
   first_seen: number | null;
   last_seen: number | null;
+  desired_firmware_id: string | null;
+  ota_status: string | null;
+};
+
+export type Firmware = {
+  id: string;
+  version: string;
+  target: string | null;
+  size: number;
+  sha256: string;
+  notes: string | null;
+  created_at: number;
 };
 
 export type FirmwareEntry = { example: string; target: string; file: string; size: number };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -70,6 +70,16 @@ export type Variable = {
   last_seen: number | null;
 };
 
+export type Device = {
+  id: string;
+  name: string;
+  chip: string | null;
+  firmware_version: string | null;
+  is_default: number;
+  first_seen: number | null;
+  last_seen: number | null;
+};
+
 export type ProjectToken = {
   id: string;
   name?: string | null;

--- a/web/test/serial-diagnosis.test.ts
+++ b/web/test/serial-diagnosis.test.ts
@@ -1,0 +1,69 @@
+// The console's plain-language read of SDK debug output. Run with
+// `bun test web/test/serial-diagnosis.test.ts`.
+
+import { test, expect } from 'bun:test';
+import { diagnose } from '../src/composables/useSerialDiagnosis';
+import type { LogEntry } from '../src/composables/useSerialLog';
+
+let id = 0;
+function nodrix(text: string): LogEntry {
+  return { id: ++id, at: 0, source: 'device', text, level: 'info', tag: 'nodrix' };
+}
+function sketch(text: string): LogEntry {
+  return { id: ++id, at: 0, source: 'device', text, level: 'info' };
+}
+
+test('says nothing until the SDK says something', () => {
+  expect(diagnose([])).toBeNull();
+  expect(diagnose([sketch('Booting...'), sketch('temp=21.5')])).toBeNull();
+});
+
+test('names a missing Wi-Fi config', () => {
+  const d = diagnose([nodrix('no wifi network set (call addAP)')]);
+  expect(d?.tone).toBe('error');
+  expect(d?.headline).toBe('No Wi-Fi network configured');
+});
+
+test('reads a 401 as a rejected token', () => {
+  const d = diagnose([nodrix('POST /v1/telemetry -> 401 (token rejected)')]);
+  expect(d?.tone).toBe('error');
+  expect(d?.headline).toBe('Token rejected');
+});
+
+test('separates a refused handshake from a dropped link', () => {
+  expect(diagnose([nodrix('connect refused - check token and host')])?.headline)
+    .toBe('The server refused the connection');
+  expect(diagnose([nodrix('connected'), nodrix('disconnected')])?.headline)
+    .toBe('Disconnected');
+});
+
+test('qualifies a failure with Wi-Fi being up', () => {
+  const d = diagnose([
+    nodrix('wifi connected: 192.168.1.42'),
+    nodrix('POST /v1/telemetry -> -1 (no connection - check host, DNS or TLS)'),
+  ]);
+  expect(d?.headline).toBe("Can't reach the server");
+  expect(d?.detail).toStartWith('Wi-Fi is up.');
+});
+
+test('does not qualify a success with Wi-Fi noise', () => {
+  const d = diagnose([nodrix('wifi connected: 192.168.1.42'), nodrix('connected')]);
+  expect(d).toEqual({ tone: 'ok', headline: 'Connected' });
+});
+
+test('reports the most recent state, not the first', () => {
+  const d = diagnose([
+    nodrix('POST /v1/telemetry -> 401 (token rejected)'),
+    nodrix('connected'),
+  ]);
+  expect(d?.headline).toBe('Connected');
+});
+
+test('carries the server code through', () => {
+  const d = diagnose([nodrix('server error: variable_limit')]);
+  expect(d?.detail).toBe('It replied with variable_limit.');
+});
+
+test('ignores sketch output that looks like SDK output', () => {
+  expect(diagnose([sketch('connect refused - check token and host')])).toBeNull();
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "types": ["vite/client"],
+    "types": ["vite/client", "w3c-web-serial"],
     "noEmit": true,
     "allowImportingTsExtensions": false,
     "useDefineForClassFields": true

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,png,ico,woff2}'],
         // og.png is only for social scrapers — no need to precache it offline.
-        globIgnores: ['**/og.png'],
+        // ~630 kB between them, and both need hardware or the network anyway.
+        globIgnores: ['**/og.png', '**/FlashPanel-*.js', '**/CodePanel-*.js'],
         navigateFallback: '/index.html',
         // Never hijack worker-rendered routes with the SPA fallback.
         navigateFallbackDenylist: [/^\/v1/, /^\/ws/, /^\/authorize/, /^\/\.well-known\//],

--- a/worker/src/domains/devices/routes.ts
+++ b/worker/src/domains/devices/routes.ts
@@ -1,0 +1,58 @@
+import { Hono } from 'hono';
+import type { Env } from '../../env';
+import { requireSession } from '../../platform/middleware/require-session';
+import { resolveProject, type ProjectContextVars } from '../../platform/middleware/resolve-project';
+import { recordAudit } from '../../platform/lib/audit';
+import { listDevices, renameDevice, forgetDevice } from './service';
+import { actorFromSession, serviceErrorResponse } from '../../platform/lib/service';
+
+const devices = new Hono<{ Bindings: Env; Variables: ProjectContextVars }>();
+
+devices.use('*', requireSession);
+devices.use('*', resolveProject);
+
+devices.get('/', async (c) => {
+  const project = c.get('project');
+  return c.json({ devices: await listDevices(c.env, project.id) });
+});
+
+devices.patch('/:id', async (c) => {
+  const project = c.get('project');
+  const id = c.req.param('id');
+  const body = await c.req.json<{ name?: string }>();
+  try {
+    const device = await renameDevice(c.env, project.id, id, body.name ?? '');
+    await recordAudit(c.env, {
+      projectId: project.id,
+      userId: c.get('user').id,
+      action: 'device.rename',
+      targetType: 'device',
+      targetId: id,
+      metadata: { name: device.name },
+    });
+    return c.json({ device });
+  } catch (e) {
+    return serviceErrorResponse(c, e);
+  }
+});
+
+devices.delete('/:id', async (c) => {
+  const project = c.get('project');
+  const id = c.req.param('id');
+  try {
+    await forgetDevice(c.env, project.id, id);
+    await recordAudit(c.env, {
+      projectId: project.id,
+      userId: c.get('user').id,
+      action: 'device.forget',
+      targetType: 'device',
+      targetId: id,
+      metadata: { source: actorFromSession(c.get('user')).source },
+    });
+    return c.body(null, 204);
+  } catch (e) {
+    return serviceErrorResponse(c, e);
+  }
+});
+
+export default devices;

--- a/worker/src/domains/devices/service.ts
+++ b/worker/src/domains/devices/service.ts
@@ -182,6 +182,30 @@ export async function forgetDevice(env: Env, projectId: string, id: string): Pro
   await projectStub(env, projectId).deleteDevice(id);
 }
 
+const SEEN_THROTTLE_MS = 60_000;
+const seenWrites = new Map<string, number>();
+
+// Ingest is hot and last_seen only needs to be roughly right.
+export async function touchDevice(env: Env, id: string): Promise<void> {
+  const nowMs = Date.now();
+  const prev = seenWrites.get(id);
+  if (prev !== undefined && nowMs - prev < SEEN_THROTTLE_MS) return;
+  seenWrites.set(id, nowMs);
+  if (seenWrites.size > 10_000) {
+    const cutoff = nowMs - SEEN_THROTTLE_MS;
+    for (const [k, t] of seenWrites) if (t < cutoff) seenWrites.delete(k);
+  }
+  const now = Math.floor(nowMs / 1000);
+  try {
+    await env.DB
+      .prepare(`UPDATE devices SET last_seen = ?, first_seen = COALESCE(first_seen, ?) WHERE id = ?`)
+      .bind(now, now, id)
+      .run();
+  } catch {
+    seenWrites.delete(id);
+  }
+}
+
 export async function recordDeviceSeen(
   env: Env,
   id: string,

--- a/worker/src/domains/devices/service.ts
+++ b/worker/src/domains/devices/service.ts
@@ -167,3 +167,23 @@ export async function forgetDevice(env: Env, projectId: string, id: string): Pro
   forgetCachedDevice(projectId, row.device_key);
   await projectStub(env, projectId).deleteDevice(id);
 }
+
+export async function recordDeviceSeen(
+  env: Env,
+  id: string,
+  chip?: string,
+  firmware?: string
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB
+    .prepare(
+      `UPDATE devices
+          SET last_seen = ?,
+              first_seen = COALESCE(first_seen, ?),
+              chip = COALESCE(?, chip),
+              firmware_version = COALESCE(?, firmware_version)
+        WHERE id = ?`
+    )
+    .bind(now, now, chip ?? null, firmware ?? null, id)
+    .run();
+}

--- a/worker/src/domains/devices/service.ts
+++ b/worker/src/domains/devices/service.ts
@@ -1,0 +1,119 @@
+import type { Env } from '../../env';
+import { newId } from '../../platform/lib/ids';
+
+export type DeviceSummary = {
+  id: string;
+  name: string;
+  chip: string | null;
+  firmware_version: string | null;
+  is_default: number;
+  first_seen: number | null;
+  last_seen: number | null;
+};
+
+// Bounds device growth from a board that reports a fresh key every boot.
+const MAX_DEVICES_PER_PROJECT = 100;
+const MAX_DEVICE_KEY_LEN = 64;
+
+// Device ids change only when a device is forgotten, so an isolate can hold the
+// project -> device mapping for as long as it lives.
+const resolved = new Map<string, string>();
+
+export function forgetCachedDevice(projectId: string, deviceKey?: string | null) {
+  resolved.delete(cacheKey(projectId, deviceKey ?? null));
+  if (deviceKey) return;
+  for (const k of resolved.keys()) if (k.startsWith(`${projectId}:`)) resolved.delete(k);
+}
+
+function cacheKey(projectId: string, deviceKey: string | null): string {
+  return `${projectId}:${deviceKey ?? ''}`;
+}
+
+// A board picks its own key, so it has to be treated as untrusted input.
+export function normaliseDeviceKey(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.length > MAX_DEVICE_KEY_LEN) return null;
+  return /^[A-Za-z0-9:._-]+$/.test(trimmed) ? trimmed : null;
+}
+
+export async function defaultDeviceId(env: Env, projectId: string): Promise<string | null> {
+  const cached = resolved.get(cacheKey(projectId, null));
+  if (cached) return cached;
+  const row = await env.DB
+    .prepare(`SELECT id FROM devices WHERE project_id = ? AND is_default = 1`)
+    .bind(projectId)
+    .first<{ id: string }>();
+  if (row) resolved.set(cacheKey(projectId, null), row.id);
+  return row?.id ?? null;
+}
+
+// Every project needs one, including projects created after the upgrade — a
+// migration alone would only cover the ones that already existed.
+export function createDefaultDevice(env: Env, projectId: string, now: number) {
+  return env.DB
+    .prepare(
+      `INSERT INTO devices (id, project_id, name, is_default, created_at)
+       VALUES (?, ?, 'Default', 1, ?)`
+    )
+    .bind(newId('device'), projectId, now);
+}
+
+// Maps what a board calls itself to a device row, creating it on first sight.
+// An unnamed board lands on the default device.
+export async function resolveDevice(
+  env: Env,
+  projectId: string,
+  deviceKey: string | null,
+  now: number
+): Promise<string | null> {
+  if (!deviceKey) return defaultDeviceId(env, projectId);
+
+  const cached = resolved.get(cacheKey(projectId, deviceKey));
+  if (cached) return cached;
+
+  const existing = await env.DB
+    .prepare(`SELECT id FROM devices WHERE project_id = ? AND device_key = ?`)
+    .bind(projectId, deviceKey)
+    .first<{ id: string }>();
+  if (existing) {
+    resolved.set(cacheKey(projectId, deviceKey), existing.id);
+    return existing.id;
+  }
+
+  const count = await env.DB
+    .prepare(`SELECT COUNT(*) AS n FROM devices WHERE project_id = ?`)
+    .bind(projectId)
+    .first<{ n: number }>();
+  if ((count?.n ?? 0) >= MAX_DEVICES_PER_PROJECT) return defaultDeviceId(env, projectId);
+
+  const id = newId('device');
+  await env.DB
+    .prepare(
+      `INSERT INTO devices (id, project_id, name, device_key, first_seen, last_seen, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(project_id, device_key) DO NOTHING`
+    )
+    .bind(id, projectId, deviceKey, deviceKey, now, now, now)
+    .run();
+
+  // A concurrent isolate may have won the insert, so read back rather than
+  // assuming the id we generated is the one that stuck.
+  const settled = await env.DB
+    .prepare(`SELECT id FROM devices WHERE project_id = ? AND device_key = ?`)
+    .bind(projectId, deviceKey)
+    .first<{ id: string }>();
+  if (settled) resolved.set(cacheKey(projectId, deviceKey), settled.id);
+  return settled?.id ?? null;
+}
+
+export async function listDevices(env: Env, projectId: string): Promise<DeviceSummary[]> {
+  const rows = await env.DB
+    .prepare(
+      `SELECT id, name, chip, firmware_version, is_default, first_seen, last_seen
+         FROM devices WHERE project_id = ? ORDER BY is_default DESC, name ASC`
+    )
+    .bind(projectId)
+    .all<DeviceSummary>();
+  return rows.results;
+}

--- a/worker/src/domains/devices/service.ts
+++ b/worker/src/domains/devices/service.ts
@@ -15,6 +15,8 @@ export type DeviceSummary = {
   is_default: number;
   first_seen: number | null;
   last_seen: number | null;
+  desired_firmware_id: string | null;
+  ota_status: string | null;
 };
 
 const MAX_DEVICES_PER_PROJECT = 100;
@@ -126,7 +128,8 @@ export async function storageIdOf(env: Env, projectId: string, deviceId: string)
 export async function listDevices(env: Env, projectId: string): Promise<DeviceSummary[]> {
   const rows = await env.DB
     .prepare(
-      `SELECT id, name, chip, firmware_version, is_default, first_seen, last_seen
+      `SELECT id, name, chip, firmware_version, is_default, first_seen, last_seen,
+              desired_firmware_id, ota_status
          FROM devices WHERE project_id = ? ORDER BY is_default DESC, name ASC`
     )
     .bind(projectId)
@@ -151,7 +154,8 @@ export async function renameDevice(
   if (res.meta.changes === 0) throw new ServiceError('not_found', 'no such device', 'unknown_device');
   const row = await env.DB
     .prepare(
-      `SELECT id, name, chip, firmware_version, is_default, first_seen, last_seen
+      `SELECT id, name, chip, firmware_version, is_default, first_seen, last_seen,
+              desired_firmware_id, ota_status
          FROM devices WHERE id = ?`
     )
     .bind(id)

--- a/worker/src/domains/devices/service.ts
+++ b/worker/src/domains/devices/service.ts
@@ -113,6 +113,16 @@ export async function resolveDevice(
   return { id: settled.id, storageId: settled.id };
 }
 
+// DO storage calls the default device '', so a D1 id passed straight through
+// silently matches nothing. Everything crossing that boundary goes through here.
+export async function storageIdOf(env: Env, projectId: string, deviceId: string): Promise<string> {
+  const row = await env.DB
+    .prepare(`SELECT is_default FROM devices WHERE id = ? AND project_id = ?`)
+    .bind(deviceId, projectId)
+    .first<{ is_default: number }>();
+  return row?.is_default ? '' : deviceId;
+}
+
 export async function listDevices(env: Env, projectId: string): Promise<DeviceSummary[]> {
   const rows = await env.DB
     .prepare(

--- a/worker/src/domains/devices/service.ts
+++ b/worker/src/domains/devices/service.ts
@@ -1,5 +1,11 @@
 import type { Env } from '../../env';
 import { newId } from '../../platform/lib/ids';
+import { ServiceError } from '../../platform/lib/service';
+import { projectStub } from '../../platform/durable-objects/stubs';
+
+// storageId is '' for the default device — the DO keys rows by it, so pre-devices
+// rows need no backfill.
+export type ResolvedDevice = { id: string; storageId: string };
 
 export type DeviceSummary = {
   id: string;
@@ -11,12 +17,9 @@ export type DeviceSummary = {
   last_seen: number | null;
 };
 
-// Bounds device growth from a board that reports a fresh key every boot.
 const MAX_DEVICES_PER_PROJECT = 100;
 const MAX_DEVICE_KEY_LEN = 64;
 
-// Device ids change only when a device is forgotten, so an isolate can hold the
-// project -> device mapping for as long as it lives.
 const resolved = new Map<string, string>();
 
 export function forgetCachedDevice(projectId: string, deviceKey?: string | null) {
@@ -29,7 +32,6 @@ function cacheKey(projectId: string, deviceKey: string | null): string {
   return `${projectId}:${deviceKey ?? ''}`;
 }
 
-// A board picks its own key, so it has to be treated as untrusted input.
 export function normaliseDeviceKey(raw: string | null | undefined): string | null {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
@@ -48,8 +50,7 @@ export async function defaultDeviceId(env: Env, projectId: string): Promise<stri
   return row?.id ?? null;
 }
 
-// Every project needs one, including projects created after the upgrade — a
-// migration alone would only cover the ones that already existed.
+// The migration only covers projects that already existed.
 export function createDefaultDevice(env: Env, projectId: string, now: number) {
   return env.DB
     .prepare(
@@ -59,18 +60,20 @@ export function createDefaultDevice(env: Env, projectId: string, now: number) {
     .bind(newId('device'), projectId, now);
 }
 
-// Maps what a board calls itself to a device row, creating it on first sight.
-// An unnamed board lands on the default device.
+// Created on first sight; a board that names nothing lands on the default device.
 export async function resolveDevice(
   env: Env,
   projectId: string,
   deviceKey: string | null,
   now: number
-): Promise<string | null> {
-  if (!deviceKey) return defaultDeviceId(env, projectId);
+): Promise<ResolvedDevice | null> {
+  if (!deviceKey) {
+    const id = await defaultDeviceId(env, projectId);
+    return id ? { id, storageId: '' } : null;
+  }
 
   const cached = resolved.get(cacheKey(projectId, deviceKey));
-  if (cached) return cached;
+  if (cached) return { id: cached, storageId: cached };
 
   const existing = await env.DB
     .prepare(`SELECT id FROM devices WHERE project_id = ? AND device_key = ?`)
@@ -78,14 +81,17 @@ export async function resolveDevice(
     .first<{ id: string }>();
   if (existing) {
     resolved.set(cacheKey(projectId, deviceKey), existing.id);
-    return existing.id;
+    return { id: existing.id, storageId: existing.id };
   }
 
   const count = await env.DB
     .prepare(`SELECT COUNT(*) AS n FROM devices WHERE project_id = ?`)
     .bind(projectId)
     .first<{ n: number }>();
-  if ((count?.n ?? 0) >= MAX_DEVICES_PER_PROJECT) return defaultDeviceId(env, projectId);
+  if ((count?.n ?? 0) >= MAX_DEVICES_PER_PROJECT) {
+    const id = await defaultDeviceId(env, projectId);
+    return id ? { id, storageId: '' } : null;
+  }
 
   const id = newId('device');
   await env.DB
@@ -97,14 +103,14 @@ export async function resolveDevice(
     .bind(id, projectId, deviceKey, deviceKey, now, now, now)
     .run();
 
-  // A concurrent isolate may have won the insert, so read back rather than
-  // assuming the id we generated is the one that stuck.
+  // A concurrent isolate may have won the insert, so read back the id that stuck.
   const settled = await env.DB
     .prepare(`SELECT id FROM devices WHERE project_id = ? AND device_key = ?`)
     .bind(projectId, deviceKey)
     .first<{ id: string }>();
-  if (settled) resolved.set(cacheKey(projectId, deviceKey), settled.id);
-  return settled?.id ?? null;
+  if (!settled) return null;
+  resolved.set(cacheKey(projectId, deviceKey), settled.id);
+  return { id: settled.id, storageId: settled.id };
 }
 
 export async function listDevices(env: Env, projectId: string): Promise<DeviceSummary[]> {
@@ -116,4 +122,48 @@ export async function listDevices(env: Env, projectId: string): Promise<DeviceSu
     .bind(projectId)
     .all<DeviceSummary>();
   return rows.results;
+}
+
+const MAX_DEVICE_NAME_LEN = 60;
+
+export async function renameDevice(
+  env: Env,
+  projectId: string,
+  id: string,
+  rawName: string
+): Promise<DeviceSummary> {
+  const name = rawName.trim().slice(0, MAX_DEVICE_NAME_LEN);
+  if (!name) throw new ServiceError('bad_request', 'name is required', 'missing_name');
+  const res = await env.DB
+    .prepare(`UPDATE devices SET name = ? WHERE id = ? AND project_id = ?`)
+    .bind(name, id, projectId)
+    .run();
+  if (res.meta.changes === 0) throw new ServiceError('not_found', 'no such device', 'unknown_device');
+  const row = await env.DB
+    .prepare(
+      `SELECT id, name, chip, firmware_version, is_default, first_seen, last_seen
+         FROM devices WHERE id = ?`
+    )
+    .bind(id)
+    .first<DeviceSummary>();
+  return row!;
+}
+
+// R2 history stays readable without the row — the device is named in each row.
+export async function forgetDevice(env: Env, projectId: string, id: string): Promise<void> {
+  const row = await env.DB
+    .prepare(`SELECT is_default, device_key FROM devices WHERE id = ? AND project_id = ?`)
+    .bind(id, projectId)
+    .first<{ is_default: number; device_key: string | null }>();
+  if (!row) throw new ServiceError('not_found', 'no such device', 'unknown_device');
+  if (row.is_default) {
+    throw new ServiceError('conflict', 'the default device cannot be forgotten', 'default_device');
+  }
+
+  await env.DB.batch([
+    env.DB.prepare(`DELETE FROM project_variables WHERE device_id = ?`).bind(id),
+    env.DB.prepare(`DELETE FROM devices WHERE id = ? AND project_id = ?`).bind(id, projectId),
+  ]);
+  forgetCachedDevice(projectId, row.device_key);
+  await projectStub(env, projectId).deleteDevice(id);
 }

--- a/worker/src/domains/firmware/admin.ts
+++ b/worker/src/domains/firmware/admin.ts
@@ -1,0 +1,81 @@
+import { Hono } from 'hono';
+import type { Env } from '../../env';
+import { requireSession } from '../../platform/middleware/require-session';
+import { resolveProject, type ProjectContextVars } from '../../platform/middleware/resolve-project';
+import { recordAudit } from '../../platform/lib/audit';
+import { serviceErrorResponse } from '../../platform/lib/service';
+import { uploadFirmware, listFirmware, deleteFirmware, assignFirmware } from './ota';
+
+const admin = new Hono<{ Bindings: Env; Variables: ProjectContextVars }>();
+
+admin.use('*', requireSession);
+admin.use('*', resolveProject);
+
+admin.get('/', async (c) => {
+  const project = c.get('project');
+  return c.json({ firmware: await listFirmware(c.env, project.id) });
+});
+
+// Raw body — the image can't ride in JSON.
+admin.post('/', async (c) => {
+  const project = c.get('project');
+  try {
+    const row = await uploadFirmware(c.env, project.id, c.get('user').id, {
+      version: c.req.query('version') ?? '',
+      target: c.req.query('target') ?? null,
+      notes: c.req.query('notes') ?? null,
+      body: await c.req.arrayBuffer(),
+    });
+    await recordAudit(c.env, {
+      projectId: project.id,
+      userId: c.get('user').id,
+      action: 'firmware.upload',
+      targetType: 'firmware',
+      targetId: row.id,
+      metadata: { version: row.version, size: row.size },
+    });
+    return c.json({ firmware: row }, 201);
+  } catch (e) {
+    return serviceErrorResponse(c, e);
+  }
+});
+
+admin.delete('/:id', async (c) => {
+  const project = c.get('project');
+  const id = c.req.param('id');
+  try {
+    await deleteFirmware(c.env, project.id, id);
+    await recordAudit(c.env, {
+      projectId: project.id,
+      userId: c.get('user').id,
+      action: 'firmware.delete',
+      targetType: 'firmware',
+      targetId: id,
+    });
+    return c.body(null, 204);
+  } catch (e) {
+    return serviceErrorResponse(c, e);
+  }
+});
+
+admin.put('/assign/:deviceId', async (c) => {
+  const project = c.get('project');
+  const deviceId = c.req.param('deviceId');
+  const body = await c.req.json<{ firmware_id?: string | null }>();
+  try {
+    await assignFirmware(c.env, project.id, deviceId, body.firmware_id ?? null);
+    await recordAudit(c.env, {
+      projectId: project.id,
+      userId: c.get('user').id,
+      action: 'firmware.assign',
+      targetType: 'device',
+      targetId: deviceId,
+      metadata: { firmware_id: body.firmware_id ?? null },
+    });
+    return c.body(null, 204);
+  } catch (e) {
+    return serviceErrorResponse(c, e);
+  }
+});
+
+export default admin;

--- a/worker/src/domains/firmware/agent.ts
+++ b/worker/src/domains/firmware/agent.ts
@@ -6,13 +6,28 @@ import { lookupUserToken, touchTokenLastUsed } from '../../platform/lib/tokens';
 import { projectStub } from '../../platform/durable-objects/stubs';
 
 const MAX_SKETCH_BYTES = 256 * 1024;
+const MAX_ARTIFACT_BYTES = 8 * 1024 * 1024;
 const SAFE_FQBN = /^[A-Za-z0-9_.:-]{1,120}$/;
+const SAFE_BUILD_ID = /^bld_[A-Za-z0-9_-]{12}$/;
+
+const ARTIFACT_MAX_AGE_MS = 60 * 60 * 1000;
+
+function artifactKey(projectId: string, buildId: string): string {
+  return `builds/${projectId}/${buildId}.bin`;
+}
+
+// A build that outran its request still uploads, and nothing will collect it.
+async function pruneArtifacts(env: Env, projectId: string): Promise<void> {
+  const cutoff = Date.now() - ARTIFACT_MAX_AGE_MS;
+  const list = await env.R2.list({ prefix: `builds/${projectId}/` });
+  const stale = list.objects.filter((o) => o.uploaded.getTime() < cutoff).map((o) => o.key);
+  if (stale.length > 0) await env.R2.delete(stale);
+}
 
 // A build runs toolchain work on somebody's physical machine, so not members.
-export async function agentWsHandler(c: Context<{ Bindings: Env }>): Promise<Response> {
+async function authoriseAgent(c: Context<{ Bindings: Env }>): Promise<string | Response> {
   const token = c.req.header('authorization')?.replace(/^Bearer\s+/i, '').trim();
   if (!token) return c.text('unauthorized', 401);
-  if (c.req.header('upgrade') !== 'websocket') return c.text('expected websocket', 426);
 
   const row = await lookupUserToken(c.env, token);
   if (!row || row.scope !== 'admin') return c.text('unauthorized', 401);
@@ -23,11 +38,38 @@ export async function agentWsHandler(c: Context<{ Bindings: Env }>): Promise<Res
   if (row.project_id && row.project_id !== projectId) return c.text('forbidden', 403);
 
   c.executionCtx.waitUntil(touchTokenLastUsed(c.env, 'user', row.id));
+  return projectId;
+}
+
+export async function agentWsHandler(c: Context<{ Bindings: Env }>): Promise<Response> {
+  if (c.req.header('upgrade') !== 'websocket') return c.text('expected websocket', 426);
+  const projectId = await authoriseAgent(c);
+  if (projectId instanceof Response) return projectId;
+
   const stub = projectStub(c.env, projectId);
   await stub.setProjectId(projectId);
   return stub.fetch(
     new Request(c.req.raw, { headers: { ...Object.fromEntries(c.req.raw.headers), 'x-nodrix-role': 'agent' } })
   );
+}
+
+// Straight to R2 — the DO is also running ingest for every board in the project.
+export async function agentArtifactHandler(c: Context<{ Bindings: Env }>): Promise<Response> {
+  const projectId = await authoriseAgent(c);
+  if (projectId instanceof Response) return projectId;
+
+  const build = c.req.param('build') ?? '';
+  if (!SAFE_BUILD_ID.test(build)) return c.text('invalid build id', 400);
+
+  const len = Number(c.req.header('content-length') ?? '0');
+  if (!Number.isFinite(len) || len <= 0) return c.text('length required', 411);
+  if (len > MAX_ARTIFACT_BYTES) return c.text('artifact too large', 413);
+  if (!c.req.raw.body) return c.text('empty body', 400);
+
+  await c.env.R2.put(artifactKey(projectId, build), c.req.raw.body, {
+    httpMetadata: { contentType: 'application/octet-stream' },
+  });
+  return c.body(null, 204);
 }
 
 const build = new Hono<{ Bindings: Env; Variables: ProjectContextVars }>();
@@ -48,9 +90,32 @@ build.post('/', async (c) => {
     return c.json({ error: 'sketch_too_large' }, 413);
   }
 
+  c.executionCtx.waitUntil(pruneArtifacts(c.env, c.get('project').id).catch(() => {}));
+
   // Held open until the agent answers — no wall-clock limit while a client waits.
   const result = await projectStub(c.env, c.get('project').id).requestBuild(fqbn, sketch);
   return c.json(result, result.ok ? 200 : 409);
+});
+
+// One-shot: the browser flashes from memory and a rebuild is cheap.
+build.get('/:id/artifact', async (c) => {
+  const user = c.get('user');
+  if (user.role !== 'owner' && user.role !== 'admin') return c.json({ error: 'forbidden' }, 403);
+
+  const id = c.req.param('id');
+  if (!SAFE_BUILD_ID.test(id)) return c.json({ error: 'invalid_build' }, 400);
+
+  const key = artifactKey(c.get('project').id, id);
+  const object = await c.env.R2.get(key);
+  if (!object) return c.json({ error: 'not_found' }, 404);
+
+  c.executionCtx.waitUntil(c.env.R2.delete(key));
+  return new Response(object.body, {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': String(object.size),
+    },
+  });
 });
 
 export default build;

--- a/worker/src/domains/firmware/agent.ts
+++ b/worker/src/domains/firmware/agent.ts
@@ -1,0 +1,56 @@
+import { Hono, type Context } from 'hono';
+import type { Env } from '../../env';
+import { requireSession } from '../../platform/middleware/require-session';
+import { resolveProject, type ProjectContextVars } from '../../platform/middleware/resolve-project';
+import { lookupUserToken, touchTokenLastUsed } from '../../platform/lib/tokens';
+import { projectStub } from '../../platform/durable-objects/stubs';
+
+const MAX_SKETCH_BYTES = 256 * 1024;
+const SAFE_FQBN = /^[A-Za-z0-9_.:-]{1,120}$/;
+
+// A build runs toolchain work on somebody's physical machine, so not members.
+export async function agentWsHandler(c: Context<{ Bindings: Env }>): Promise<Response> {
+  const token = c.req.header('authorization')?.replace(/^Bearer\s+/i, '').trim();
+  if (!token) return c.text('unauthorized', 401);
+  if (c.req.header('upgrade') !== 'websocket') return c.text('expected websocket', 426);
+
+  const row = await lookupUserToken(c.env, token);
+  if (!row || row.scope !== 'admin') return c.text('unauthorized', 401);
+  if (row.role !== 'owner' && row.role !== 'admin') return c.text('forbidden', 403);
+
+  const projectId = c.req.query('project') ?? row.project_id;
+  if (!projectId) return c.text('project required', 400);
+  if (row.project_id && row.project_id !== projectId) return c.text('forbidden', 403);
+
+  c.executionCtx.waitUntil(touchTokenLastUsed(c.env, 'user', row.id));
+  const stub = projectStub(c.env, projectId);
+  await stub.setProjectId(projectId);
+  return stub.fetch(
+    new Request(c.req.raw, { headers: { ...Object.fromEntries(c.req.raw.headers), 'x-nodrix-role': 'agent' } })
+  );
+}
+
+const build = new Hono<{ Bindings: Env; Variables: ProjectContextVars }>();
+
+build.use('*', requireSession);
+build.use('*', resolveProject);
+
+build.post('/', async (c) => {
+  const user = c.get('user');
+  if (user.role !== 'owner' && user.role !== 'admin') return c.json({ error: 'forbidden' }, 403);
+
+  const body = await c.req.json<{ fqbn?: string; sketch?: string }>();
+  const fqbn = (body.fqbn ?? '').trim();
+  const sketch = body.sketch ?? '';
+  if (!SAFE_FQBN.test(fqbn)) return c.json({ error: 'invalid_fqbn' }, 400);
+  if (!sketch.trim()) return c.json({ error: 'empty_sketch' }, 400);
+  if (new TextEncoder().encode(sketch).length > MAX_SKETCH_BYTES) {
+    return c.json({ error: 'sketch_too_large' }, 413);
+  }
+
+  // Held open until the agent answers — no wall-clock limit while a client waits.
+  const result = await projectStub(c.env, c.get('project').id).requestBuild(fqbn, sketch);
+  return c.json(result, result.ok ? 200 : 409);
+});
+
+export default build;

--- a/worker/src/domains/firmware/device.ts
+++ b/worker/src/domains/firmware/device.ts
@@ -1,0 +1,43 @@
+import { Hono } from 'hono';
+import type { Env } from '../../env';
+import { requireProjectToken, type ProjectTokenContextVars } from '../../platform/middleware/require-project-token';
+import { normaliseDeviceKey, resolveDevice } from '../devices/service';
+import { offerFor, openImage } from './ota';
+
+const ota = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
+
+ota.use('*', requireProjectToken);
+
+async function deviceIdFor(c: { env: Env; req: { header: (n: string) => string | undefined } }, projectId: string) {
+  const device = await resolveDevice(
+    c.env,
+    projectId,
+    normaliseDeviceKey(c.req.header('x-nodrix-device')),
+    Math.floor(Date.now() / 1000)
+  );
+  return device?.id ?? null;
+}
+
+// null means the board is already where it should be.
+ota.get('/', async (c) => {
+  const { project_id } = c.get('projectToken');
+  const deviceId = await deviceIdFor(c, project_id);
+  if (!deviceId) return c.json({ update: null });
+  return c.json({ update: await offerFor(c.env, project_id, deviceId) });
+});
+
+ota.get('/image', async (c) => {
+  const { project_id } = c.get('projectToken');
+  const deviceId = await deviceIdFor(c, project_id);
+  if (!deviceId) return c.json({ error: 'not_found' }, 404);
+  const object = await openImage(c.env, project_id, deviceId);
+  if (!object) return c.json({ error: 'not_found' }, 404);
+  return new Response(object.body, {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': String(object.size),
+    },
+  });
+});
+
+export default ota;

--- a/worker/src/domains/firmware/device.ts
+++ b/worker/src/domains/firmware/device.ts
@@ -1,8 +1,8 @@
 import { Hono, type Context } from 'hono';
 import type { Env } from '../../env';
 import { requireProjectToken, type ProjectTokenContextVars } from '../../platform/middleware/require-project-token';
-import { normaliseDeviceKey, resolveDevice, touchDevice } from '../devices/service';
-import { offerFor, openImage } from './ota';
+import { normaliseDeviceKey, recordDeviceSeen, resolveDevice, touchDevice } from '../devices/service';
+import { offerFor, openImage, reconcile } from './ota';
 import { projectStub } from '../../platform/durable-objects/stubs';
 import { storageIdOf } from '../devices/service';
 
@@ -12,23 +12,33 @@ const ota = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
 
 ota.use('*', requireProjectToken);
 
-async function deviceIdFor(c: OtaContext, projectId: string) {
+async function deviceIdFor(c: OtaContext, projectId: string, seen = true) {
   const device = await resolveDevice(
     c.env,
     projectId,
     normaliseDeviceKey(c.req.header('x-nodrix-device')),
     Math.floor(Date.now() / 1000)
   );
-  if (device) c.executionCtx.waitUntil(touchDevice(c.env, device.id));
+  if (device && seen) c.executionCtx.waitUntil(touchDevice(c.env, device.id));
   return device?.id ?? null;
 }
 
 // null means the board is already where it should be.
 ota.get('/', async (c) => {
   const { project_id } = c.get('projectToken');
-  const deviceId = await deviceIdFor(c, project_id);
+  // An HTTP-mode board has no hello frame, so this is where it reports what it
+  // runs — without it a finished update is offered again forever.
+  const firmware = c.req.header('x-nodrix-firmware') ?? null;
+  const deviceId = await deviceIdFor(c, project_id, !firmware);
   if (!deviceId) return c.json({ update: null });
-  return c.json({ update: await offerFor(c.env, project_id, deviceId) });
+
+  if (firmware) {
+    c.executionCtx.waitUntil(
+      recordDeviceSeen(c.env, deviceId, c.req.header('x-nodrix-chip'), firmware)
+        .then(() => reconcile(c.env, deviceId, firmware))
+    );
+  }
+  return c.json({ update: await offerFor(c.env, project_id, deviceId, firmware) });
 });
 
 ota.get('/image', async (c) => {

--- a/worker/src/domains/firmware/device.ts
+++ b/worker/src/domains/firmware/device.ts
@@ -1,22 +1,25 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import type { Env } from '../../env';
 import { requireProjectToken, type ProjectTokenContextVars } from '../../platform/middleware/require-project-token';
-import { normaliseDeviceKey, resolveDevice } from '../devices/service';
+import { normaliseDeviceKey, resolveDevice, touchDevice } from '../devices/service';
 import { offerFor, openImage } from './ota';
 import { projectStub } from '../../platform/durable-objects/stubs';
 import { storageIdOf } from '../devices/service';
+
+type OtaContext = Context<{ Bindings: Env; Variables: ProjectTokenContextVars }>;
 
 const ota = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
 
 ota.use('*', requireProjectToken);
 
-async function deviceIdFor(c: { env: Env; req: { header: (n: string) => string | undefined } }, projectId: string) {
+async function deviceIdFor(c: OtaContext, projectId: string) {
   const device = await resolveDevice(
     c.env,
     projectId,
     normaliseDeviceKey(c.req.header('x-nodrix-device')),
     Math.floor(Date.now() / 1000)
   );
+  if (device) c.executionCtx.waitUntil(touchDevice(c.env, device.id));
   return device?.id ?? null;
 }
 

--- a/worker/src/domains/firmware/device.ts
+++ b/worker/src/domains/firmware/device.ts
@@ -3,6 +3,8 @@ import type { Env } from '../../env';
 import { requireProjectToken, type ProjectTokenContextVars } from '../../platform/middleware/require-project-token';
 import { normaliseDeviceKey, resolveDevice } from '../devices/service';
 import { offerFor, openImage } from './ota';
+import { projectStub } from '../../platform/durable-objects/stubs';
+import { storageIdOf } from '../devices/service';
 
 const ota = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
 
@@ -30,6 +32,11 @@ ota.get('/image', async (c) => {
   const { project_id } = c.get('projectToken');
   const deviceId = await deviceIdFor(c, project_id);
   if (!deviceId) return c.json({ error: 'not_found' }, 404);
+  const storageId = await storageIdOf(c.env, project_id, deviceId);
+  if (!(await projectStub(c.env, project_id).consumeOtaQuota(storageId))) {
+    return c.json({ error: 'too_many_requests' }, 429, { 'retry-after': '3600' });
+  }
+
   const object = await openImage(c.env, project_id, deviceId);
   if (!object) return c.json({ error: 'not_found' }, 404);
   return new Response(object.body, {

--- a/worker/src/domains/firmware/ota.ts
+++ b/worker/src/domains/firmware/ota.ts
@@ -1,0 +1,160 @@
+import type { Env } from '../../env';
+import { newId } from '../../platform/lib/ids';
+import { ServiceError } from '../../platform/lib/service';
+import { projectStub } from '../../platform/durable-objects/stubs';
+import { storageIdOf } from '../devices/service';
+
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const SAFE_VERSION = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
+
+export type FirmwareRow = {
+  id: string;
+  version: string;
+  target: string | null;
+  size: number;
+  sha256: string;
+  notes: string | null;
+  created_at: number;
+};
+
+function r2Key(projectId: string, firmwareId: string): string {
+  return `firmware/${projectId}/${firmwareId}.bin`;
+}
+
+export async function uploadFirmware(
+  env: Env,
+  projectId: string,
+  userId: string,
+  input: { version: string; target?: string | null; notes?: string | null; body: ArrayBuffer }
+): Promise<FirmwareRow> {
+  const version = input.version.trim();
+  if (!SAFE_VERSION.test(version)) {
+    throw new ServiceError('bad_request', 'version must be alphanumeric', 'invalid_version');
+  }
+  if (input.body.byteLength === 0) {
+    throw new ServiceError('bad_request', 'image is empty', 'empty_image');
+  }
+  if (input.body.byteLength > MAX_IMAGE_BYTES) {
+    throw new ServiceError('bad_request', 'image is too large', 'image_too_large');
+  }
+
+  const digest = await crypto.subtle.digest('SHA-256', input.body);
+  const sha256 = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+
+  const id = newId('firmware');
+  const key = r2Key(projectId, id);
+  const now = Math.floor(Date.now() / 1000);
+
+  await env.R2.put(key, input.body, { httpMetadata: { contentType: 'application/octet-stream' } });
+  try {
+    await env.DB
+      .prepare(
+        `INSERT INTO firmware (id, project_id, version, target, size, sha256, r2_key, notes, created_by, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(id, projectId, version, input.target ?? null, input.body.byteLength, sha256, key, input.notes ?? null, userId, now)
+      .run();
+  } catch {
+    // Don't leave an image in R2 that no row points at.
+    await env.R2.delete(key).catch(() => {});
+    throw new ServiceError('conflict', 'that version already exists', 'duplicate_version');
+  }
+
+  return { id, version, target: input.target ?? null, size: input.body.byteLength, sha256, notes: input.notes ?? null, created_at: now };
+}
+
+export async function listFirmware(env: Env, projectId: string): Promise<FirmwareRow[]> {
+  const rows = await env.DB
+    .prepare(
+      `SELECT id, version, target, size, sha256, notes, created_at
+         FROM firmware WHERE project_id = ? ORDER BY created_at DESC`
+    )
+    .bind(projectId)
+    .all<FirmwareRow>();
+  return rows.results;
+}
+
+export async function deleteFirmware(env: Env, projectId: string, id: string): Promise<void> {
+  const row = await env.DB
+    .prepare(`SELECT r2_key FROM firmware WHERE id = ? AND project_id = ?`)
+    .bind(id, projectId)
+    .first<{ r2_key: string }>();
+  if (!row) throw new ServiceError('not_found', 'no such firmware', 'unknown_firmware');
+  await env.DB.prepare(`DELETE FROM firmware WHERE id = ? AND project_id = ?`).bind(id, projectId).run();
+  await env.R2.delete(row.r2_key).catch(() => {});
+}
+
+// Setting desired state is the whole of starting an update.
+export async function assignFirmware(
+  env: Env,
+  projectId: string,
+  deviceId: string,
+  firmwareId: string | null
+): Promise<void> {
+  if (firmwareId) {
+    const fw = await env.DB
+      .prepare(`SELECT 1 AS ok FROM firmware WHERE id = ? AND project_id = ?`)
+      .bind(firmwareId, projectId)
+      .first<{ ok: number }>();
+    if (!fw) throw new ServiceError('not_found', 'no such firmware', 'unknown_firmware');
+  }
+  const res = await env.DB
+    .prepare(
+      `UPDATE devices SET desired_firmware_id = ?, ota_status = ?, ota_updated_at = ?
+        WHERE id = ? AND project_id = ?`
+    )
+    .bind(firmwareId, firmwareId ? 'pending' : null, Math.floor(Date.now() / 1000), deviceId, projectId)
+    .run();
+  if (res.meta.changes === 0) throw new ServiceError('not_found', 'no such device', 'unknown_device');
+
+  // Best-effort — the board would find it at its next poll anyway.
+  if (firmwareId) {
+    const storageId = await storageIdOf(env, projectId, deviceId);
+    await projectStub(env, projectId).notifyOta(storageId).catch(() => {});
+  }
+}
+
+export type UpdateOffer = { version: string; size: number; sha256: string; url: string } | null;
+
+// Reported vs desired is the whole reconciliation; there is no job to track.
+export async function offerFor(env: Env, projectId: string, deviceId: string): Promise<UpdateOffer> {
+  const row = await env.DB
+    .prepare(
+      `SELECT f.version AS version, f.size AS size, f.sha256 AS sha256, d.firmware_version AS current
+         FROM devices d JOIN firmware f ON f.id = d.desired_firmware_id
+        WHERE d.id = ? AND d.project_id = ?`
+    )
+    .bind(deviceId, projectId)
+    .first<{ version: string; size: number; sha256: string; current: string | null }>();
+  if (!row || row.current === row.version) return null;
+  return { version: row.version, size: row.size, sha256: row.sha256, url: '/v1/ota/image' };
+}
+
+export async function openImage(env: Env, projectId: string, deviceId: string): Promise<R2ObjectBody | null> {
+  const row = await env.DB
+    .prepare(
+      `SELECT f.r2_key AS r2_key FROM devices d JOIN firmware f ON f.id = d.desired_firmware_id
+        WHERE d.id = ? AND d.project_id = ?`
+    )
+    .bind(deviceId, projectId)
+    .first<{ r2_key: string }>();
+  if (!row) return null;
+  return env.R2.get(row.r2_key);
+}
+
+// Only the board knows it booted, so reporting the version is the success signal.
+export async function reconcile(env: Env, deviceId: string, reported: string | null): Promise<void> {
+  if (!reported) return;
+  await env.DB
+    .prepare(
+      `UPDATE devices
+          SET ota_status = CASE
+                WHEN desired_firmware_id IS NULL THEN NULL
+                WHEN ? = (SELECT version FROM firmware WHERE id = desired_firmware_id) THEN 'ok'
+                ELSE ota_status END,
+              ota_updated_at = ?
+        WHERE id = ?`
+    )
+    .bind(reported, Math.floor(Date.now() / 1000), deviceId)
+    .run();
+}

--- a/worker/src/domains/firmware/ota.ts
+++ b/worker/src/domains/firmware/ota.ts
@@ -142,7 +142,14 @@ export async function assignFirmware(
 export type UpdateOffer = { version: string; size: number; sha256: string; url: string } | null;
 
 // Reported vs desired is the whole reconciliation; there is no job to track.
-export async function offerFor(env: Env, projectId: string, deviceId: string): Promise<UpdateOffer> {
+// A version the board claims in this request beats the stored one, which may not
+// have caught up with the update it just applied.
+export async function offerFor(
+  env: Env,
+  projectId: string,
+  deviceId: string,
+  reported?: string | null
+): Promise<UpdateOffer> {
   const row = await env.DB
     .prepare(
       `SELECT f.version AS version, f.size AS size, f.sha256 AS sha256, d.firmware_version AS current
@@ -151,7 +158,7 @@ export async function offerFor(env: Env, projectId: string, deviceId: string): P
     )
     .bind(deviceId, projectId)
     .first<{ version: string; size: number; sha256: string; current: string | null }>();
-  if (!row || row.current === row.version) return null;
+  if (!row || (reported ?? row.current) === row.version) return null;
   return { version: row.version, size: row.size, sha256: row.sha256, url: '/v1/ota/image' };
 }
 

--- a/worker/src/domains/firmware/ota.ts
+++ b/worker/src/domains/firmware/ota.ts
@@ -5,6 +5,7 @@ import { projectStub } from '../../platform/durable-objects/stubs';
 import { storageIdOf } from '../devices/service';
 
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const KEEP_VERSIONS = 10;
 const SAFE_VERSION = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
 
 export type FirmwareRow = {
@@ -60,7 +61,31 @@ export async function uploadFirmware(
     throw new ServiceError('conflict', 'that version already exists', 'duplicate_version');
   }
 
+  await prune(env, projectId).catch(() => {});
   return { id, version, target: input.target ?? null, size: input.body.byteLength, sha256, notes: input.notes ?? null, created_at: now };
+}
+
+// Spares anything a device runs or is waiting to run; deleting those strands a
+// pending update or loses the image a board is on.
+async function prune(env: Env, projectId: string): Promise<void> {
+  const stale = await env.DB
+    .prepare(
+      `SELECT id, r2_key FROM firmware
+        WHERE project_id = ?
+          AND id NOT IN (SELECT id FROM firmware WHERE project_id = ? ORDER BY created_at DESC LIMIT ?)
+          AND id NOT IN (SELECT desired_firmware_id FROM devices
+                          WHERE project_id = ? AND desired_firmware_id IS NOT NULL)
+          AND version NOT IN (SELECT firmware_version FROM devices
+                               WHERE project_id = ? AND firmware_version IS NOT NULL)`
+    )
+    .bind(projectId, projectId, KEEP_VERSIONS, projectId, projectId)
+    .all<{ id: string; r2_key: string }>();
+  if (stale.results.length === 0) return;
+
+  await env.DB.batch(
+    stale.results.map((r) => env.DB.prepare(`DELETE FROM firmware WHERE id = ?`).bind(r.id))
+  );
+  await env.R2.delete(stale.results.map((r) => r.r2_key)).catch(() => {});
 }
 
 export async function listFirmware(env: Env, projectId: string): Promise<FirmwareRow[]> {

--- a/worker/src/domains/firmware/routes.ts
+++ b/worker/src/domains/firmware/routes.ts
@@ -1,0 +1,23 @@
+import { Hono } from 'hono';
+import type { Env } from '../../env';
+import { requireSession } from '../../platform/middleware/require-session';
+import { getCatalog, fetchBinary } from './service';
+
+const firmware = new Hono<{ Bindings: Env }>();
+
+firmware.use('*', requireSession);
+
+firmware.get('/catalog', async (c) => c.json(await getCatalog(c.env)));
+
+firmware.get('/binary/:tag/:file', async (c) => {
+  const res = await fetchBinary(c.req.param('tag'), c.req.param('file'));
+  if (!res) return c.json({ error: 'not_found' }, 404);
+  return new Response(res.body, {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+});
+
+export default firmware;

--- a/worker/src/domains/firmware/service.ts
+++ b/worker/src/domains/firmware/service.ts
@@ -1,0 +1,85 @@
+import type { Env } from '../../env';
+
+// Prebuilt example binaries are published as release assets on the SDK repo.
+const SDK_REPO = 'decoded-cipher/nodrix-sdk';
+const CACHE_KEY = `firmware:catalog:${SDK_REPO}`;
+const FRESH_SECONDS = 15 * 60;
+
+// Assets are named <Example>-<target>.bin by the SDK's compile workflow.
+const ASSET_NAME = /^([A-Za-z0-9_]+)-([A-Za-z0-9_]+)\.bin$/;
+// Anything reaching the download URL is built from these, so they decide whether
+// this is a firmware proxy or an open one.
+const SAFE_TAG = /^[A-Za-z0-9._-]{1,64}$/;
+const SAFE_NAME = /^[A-Za-z0-9._-]{1,128}\.bin$/;
+
+export type FirmwareEntry = { example: string; target: string; file: string; size: number };
+export type FirmwareCatalog = { tag: string | null; entries: FirmwareEntry[] };
+
+type Cached = FirmwareCatalog & { fetched_at: number; etag: string | null };
+
+export async function getCatalog(env: Env): Promise<FirmwareCatalog> {
+  const now = Math.floor(Date.now() / 1000);
+  let cached: Cached | null = null;
+  try {
+    cached = await env.KV.get<Cached>(CACHE_KEY, 'json');
+  } catch { /* KV miss → fetch */ }
+  if (cached && now - cached.fetched_at < FRESH_SECONDS) {
+    return { tag: cached.tag, entries: cached.entries };
+  }
+
+  const headers: Record<string, string> = {
+    'User-Agent': 'nodrix-firmware-catalog',
+    Accept: 'application/vnd.github+json',
+  };
+  if (cached?.etag) headers['If-None-Match'] = cached.etag;
+
+  let res: Response;
+  try {
+    res = await fetch(`https://api.github.com/repos/${SDK_REPO}/releases/latest`, { headers });
+  } catch {
+    return cached ? { tag: cached.tag, entries: cached.entries } : { tag: null, entries: [] };
+  }
+
+  if (res.status === 304 && cached) {
+    await put(env, { ...cached, fetched_at: now });
+    return { tag: cached.tag, entries: cached.entries };
+  }
+  if (!res.ok) {
+    // No release yet is a normal state, not an error worth surfacing.
+    return cached ? { tag: cached.tag, entries: cached.entries } : { tag: null, entries: [] };
+  }
+
+  const body = (await res.json()) as {
+    tag_name?: string;
+    assets?: Array<{ name?: string; size?: number }>;
+  };
+  const entries: FirmwareEntry[] = [];
+  for (const asset of body.assets ?? []) {
+    const m = ASSET_NAME.exec(asset.name ?? '');
+    if (!m) continue;
+    entries.push({ example: m[1]!, target: m[2]!, file: asset.name!, size: asset.size ?? 0 });
+  }
+  const catalog: FirmwareCatalog = { tag: body.tag_name ?? null, entries };
+  await put(env, { ...catalog, fetched_at: now, etag: res.headers.get('etag') });
+  return catalog;
+}
+
+function put(env: Env, value: Cached): Promise<void> {
+  return env.KV.put(CACHE_KEY, JSON.stringify(value)).catch(() => {});
+}
+
+// The client passes parts, never a URL. '..' is rejected separately because the
+// charset allows dots, and ../ would climb out of the release path.
+export function binaryUrl(tag: string, file: string): string | null {
+  if (!SAFE_TAG.test(tag) || !SAFE_NAME.test(file)) return null;
+  if (tag.includes('..') || file.includes('..')) return null;
+  return `https://github.com/${SDK_REPO}/releases/download/${tag}/${file}`;
+}
+
+// Release assets carry no CORS headers, so the browser can't fetch one itself.
+export async function fetchBinary(tag: string, file: string): Promise<Response | null> {
+  const url = binaryUrl(tag, file);
+  if (!url) return null;
+  const res = await fetch(url, { headers: { 'User-Agent': 'nodrix-firmware-proxy' } });
+  return res.ok ? res : null;
+}

--- a/worker/src/domains/projects/export.ts
+++ b/worker/src/domains/projects/export.ts
@@ -1,0 +1,74 @@
+import type { Env } from '../../env';
+
+// A project as NDJSON, one typed record per line. Streamed: a year of history is
+// larger than anything that should sit in memory. Carries no secrets — token
+// hashes, sealed integration config and share tokens are all omitted.
+
+type Row = Record<string, unknown>;
+
+function line(type: string, data: Row): string {
+  return `${JSON.stringify({ type, ...data })}\n`;
+}
+
+async function* records(env: Env, projectId: string): AsyncGenerator<string> {
+  const project = await env.DB
+    .prepare(`SELECT id, name, description, created_at, updated_at FROM projects WHERE id = ?`)
+    .bind(projectId)
+    .first<Row>();
+  if (!project) return;
+
+  yield line('project', { exported_at: Math.floor(Date.now() / 1000), project });
+
+  const tables: Array<[string, string]> = [
+    ['device', `SELECT id, name, device_key, chip, firmware_version, is_default, first_seen, last_seen, created_at
+                  FROM devices WHERE project_id = ?`],
+    ['variable', `SELECT id, device_id, key, unit, created_at, updated_at, last_seen
+                    FROM project_variables WHERE project_id = ?`],
+    ['dashboard', `SELECT id, name, description, layout, visibility, created_at, updated_at
+                     FROM dashboards WHERE project_id = ?`],
+    ['automation', `SELECT id, name, description, enabled, trigger_type, graph, created_at, updated_at
+                      FROM automations WHERE project_id = ?`],
+    ['integration', `SELECT id, name, kind, enabled, created_at, updated_at
+                       FROM integrations WHERE project_id = ?`],
+    ['firmware', `SELECT id, version, target, size, sha256, notes, created_at
+                    FROM firmware WHERE project_id = ?`],
+  ];
+
+  for (const [type, sql] of tables) {
+    const rows = await env.DB.prepare(sql).bind(projectId).all<Row>();
+    for (const row of rows.results) yield line(type, row);
+  }
+
+  // Already NDJSON in R2; re-tagged so the whole file reads uniformly.
+  let cursor: string | undefined;
+  do {
+    const list = await env.R2.list({ prefix: `telemetry/${projectId}/`, ...(cursor ? { cursor } : {}) });
+    for (const object of list.objects) {
+      const body = await env.R2.get(object.key);
+      if (!body) continue;
+      const text = await body.text();
+      for (const raw of text.split('\n')) {
+        if (!raw.trim()) continue;
+        try {
+          yield line('telemetry', JSON.parse(raw) as Row);
+        } catch { /* a truncated line beats aborting the export */ }
+      }
+    }
+    cursor = list.truncated ? list.cursor : undefined;
+  } while (cursor);
+}
+
+export function exportProject(env: Env, projectId: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const iterator = records(env, projectId);
+  return new ReadableStream({
+    async pull(controller) {
+      const next = await iterator.next();
+      if (next.done) controller.close();
+      else controller.enqueue(encoder.encode(next.value));
+    },
+    cancel() {
+      void iterator.return(undefined);
+    },
+  });
+}

--- a/worker/src/domains/projects/routes.ts
+++ b/worker/src/domains/projects/routes.ts
@@ -4,6 +4,7 @@ import { requireSession, type UserContextVars } from '../../platform/middleware/
 import { recordAudit } from '../../platform/lib/audit';
 import { userCanAccessProject } from '../../platform/lib/roles';
 import { projectStub } from '../../platform/durable-objects/stubs';
+import { exportProject } from './export';
 import { createProject, updateProject, listAccessibleProjects } from './service';
 import { actorFromSession, serviceErrorResponse } from '../../platform/lib/service';
 
@@ -50,6 +51,29 @@ projects.post('/:proj/flush', async (c) => {
 
   const result = await projectStub(c.env, projId).flushNow();
   return c.json(result);
+});
+
+// Everything the project owns, as NDJSON. Streamed — a project with a year of
+// history is far too big to assemble in memory. Carries no secrets.
+projects.get('/:proj/export', async (c) => {
+  const projId = c.req.param('proj');
+  const user = c.get('user');
+  if (!(await userCanAccessProject(c.env, user.id, projId))) return c.json({ error: 'forbidden' }, 403);
+
+  await recordAudit(c.env, {
+    projectId: projId,
+    userId: user.id,
+    action: 'project.export',
+    targetType: 'project',
+    targetId: projId,
+  });
+
+  return new Response(exportProject(c.env, projId), {
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+      'Content-Disposition': `attachment; filename="${projId}.ndjson"`,
+    },
+  });
 });
 
 // Cascade: wipes the project's Project DO (which owns R2 telemetry history, not

--- a/worker/src/domains/projects/service.ts
+++ b/worker/src/domains/projects/service.ts
@@ -1,6 +1,7 @@
 import type { Env } from '../../env';
 import { type Actor, isInstanceAdmin, ServiceError } from '../../platform/lib/service';
 import { newId } from '../../platform/lib/ids';
+import { createDefaultDevice } from '../devices/service';
 import { recordAudit } from '../../platform/lib/audit';
 import { buildUpdate, chunk, inClause, MAX_BOUND_PARAMS } from '../../platform/lib/sql';
 
@@ -103,12 +104,13 @@ export async function createProject(
 
   const id = newId('project');
   const now = Math.floor(Date.now() / 1000);
-  await env.DB
-    .prepare(
-      `INSERT INTO projects (id, name, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-    )
-    .bind(id, name, actor.userId, now, now)
-    .run();
+  // One batch so a project can never exist without its default device.
+  await env.DB.batch([
+    env.DB
+      .prepare(`INSERT INTO projects (id, name, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`)
+      .bind(id, name, actor.userId, now, now),
+    createDefaultDevice(env, id, now),
+  ]);
 
   await recordAudit(env, {
     projectId: id,

--- a/worker/src/domains/telemetry/control.ts
+++ b/worker/src/domains/telemetry/control.ts
@@ -3,7 +3,7 @@ import type { Env } from '../../env';
 import { requireProjectToken, type ProjectTokenContextVars } from '../../platform/middleware/require-project-token';
 import { lookupProjectToken, touchTokenLastUsed } from '../../platform/lib/tokens';
 import { projectStub } from '../../platform/durable-objects/stubs';
-import { normaliseDeviceKey, resolveDevice } from '../devices/service';
+import { normaliseDeviceKey, resolveDevice, touchDevice } from '../devices/service';
 
 const control = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
 
@@ -19,6 +19,7 @@ control.get('/', async (c) => {
     normaliseDeviceKey(c.req.header('x-nodrix-device')),
     Math.floor(Date.now() / 1000)
   );
+  if (device) c.executionCtx.waitUntil(touchDevice(c.env, device.id));
   const stub = projectStub(c.env, project_id);
   const pending = await stub.listPendingControl(device?.storageId ?? '');
   return c.json({ control: pending });

--- a/worker/src/domains/telemetry/control.ts
+++ b/worker/src/domains/telemetry/control.ts
@@ -3,6 +3,7 @@ import type { Env } from '../../env';
 import { requireProjectToken, type ProjectTokenContextVars } from '../../platform/middleware/require-project-token';
 import { lookupProjectToken, touchTokenLastUsed } from '../../platform/lib/tokens';
 import { projectStub } from '../../platform/durable-objects/stubs';
+import { normaliseDeviceKey, resolveDevice } from '../devices/service';
 
 const control = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
 
@@ -12,8 +13,14 @@ control.use('*', requireProjectToken);
 // Pending cloud->hardware variable writes for the authenticated project.
 control.get('/', async (c) => {
   const { project_id } = c.get('projectToken');
+  const device = await resolveDevice(
+    c.env,
+    project_id,
+    normaliseDeviceKey(c.req.header('x-nodrix-device')),
+    Math.floor(Date.now() / 1000)
+  );
   const stub = projectStub(c.env, project_id);
-  const pending = await stub.listPendingControl();
+  const pending = await stub.listPendingControl(device?.storageId ?? '');
   return c.json({ control: pending });
 });
 
@@ -24,8 +31,14 @@ control.post('/ack', async (c) => {
   if (ids.length === 0) return c.json({ acked: 0 });
 
   const { project_id } = c.get('projectToken');
+  const device = await resolveDevice(
+    c.env,
+    project_id,
+    normaliseDeviceKey(c.req.header('x-nodrix-device')),
+    Math.floor(Date.now() / 1000)
+  );
   const stub = projectStub(c.env, project_id);
-  const result = await stub.ackControl(ids);
+  const result = await stub.ackControl(ids, device?.storageId ?? '');
   return c.json(result);
 });
 

--- a/worker/src/domains/telemetry/telemetry.ts
+++ b/worker/src/domains/telemetry/telemetry.ts
@@ -43,15 +43,15 @@ telemetry.post('/', async (c) => {
   const { project_id } = c.get('projectToken');
   const now = Math.floor(Date.now() / 1000);
   const deviceKey = normaliseDeviceKey(c.req.header('x-nodrix-device'));
-  const deviceId = await resolveDevice(c.env, project_id, deviceKey, now);
+  const device = await resolveDevice(c.env, project_id, deviceKey, now);
 
   const stub = projectStub(c.env, project_id);
-  await stub.ingest(project_id, points);
+  await stub.ingest(project_id, points, device?.storageId ?? '');
 
   // Auto-create new variables + bump last_seen off the response path (best-effort).
-  if (deviceId) {
+  if (device) {
     c.executionCtx.waitUntil(
-      upsertVariables(c.env, project_id, deviceId, points.map((p) => p.variable), now)
+      upsertVariables(c.env, project_id, device.id, points.map((p) => p.variable), now)
     );
   }
 

--- a/worker/src/domains/telemetry/telemetry.ts
+++ b/worker/src/domains/telemetry/telemetry.ts
@@ -4,7 +4,7 @@ import { requireProjectToken, type ProjectTokenContextVars } from '../../platfor
 import { projectStub } from '../../platform/durable-objects/stubs';
 import { parseTelemetryBody, MAX_POINTS, MAX_KEY_LEN, MAX_STRING_VALUE } from './validate';
 import { upsertVariables } from './variables';
-import { normaliseDeviceKey, resolveDevice } from '../devices/service';
+import { normaliseDeviceKey, resolveDevice, touchDevice } from '../devices/service';
 
 const telemetry = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
 
@@ -51,7 +51,10 @@ telemetry.post('/', async (c) => {
   // Auto-create new variables + bump last_seen off the response path (best-effort).
   if (device) {
     c.executionCtx.waitUntil(
-      upsertVariables(c.env, project_id, device.id, points.map((p) => p.variable), now)
+      Promise.all([
+        upsertVariables(c.env, project_id, device.id, points.map((p) => p.variable), now),
+        touchDevice(c.env, device.id),
+      ])
     );
   }
 

--- a/worker/src/domains/telemetry/telemetry.ts
+++ b/worker/src/domains/telemetry/telemetry.ts
@@ -4,6 +4,7 @@ import { requireProjectToken, type ProjectTokenContextVars } from '../../platfor
 import { projectStub } from '../../platform/durable-objects/stubs';
 import { parseTelemetryBody, MAX_POINTS, MAX_KEY_LEN, MAX_STRING_VALUE } from './validate';
 import { upsertVariables } from './variables';
+import { normaliseDeviceKey, resolveDevice } from '../devices/service';
 
 const telemetry = new Hono<{ Bindings: Env; Variables: ProjectTokenContextVars }>();
 
@@ -40,14 +41,19 @@ telemetry.post('/', async (c) => {
   const points = parsed.points;
 
   const { project_id } = c.get('projectToken');
+  const now = Math.floor(Date.now() / 1000);
+  const deviceKey = normaliseDeviceKey(c.req.header('x-nodrix-device'));
+  const deviceId = await resolveDevice(c.env, project_id, deviceKey, now);
+
   const stub = projectStub(c.env, project_id);
   await stub.ingest(project_id, points);
 
   // Auto-create new variables + bump last_seen off the response path (best-effort).
-  const now = Math.floor(Date.now() / 1000);
-  c.executionCtx.waitUntil(
-    upsertVariables(c.env, project_id, points.map((p) => p.variable), now)
-  );
+  if (deviceId) {
+    c.executionCtx.waitUntil(
+      upsertVariables(c.env, project_id, deviceId, points.map((p) => p.variable), now)
+    );
+  }
 
   return c.body(null, 204);
 });

--- a/worker/src/domains/telemetry/variables.ts
+++ b/worker/src/domains/telemetry/variables.ts
@@ -12,8 +12,8 @@ const MAX_VARIABLES_PER_PROJECT = 250;
 const LAST_SEEN_THROTTLE_MS = 60_000;
 const lastSeenWrites = new Map<string, number>();
 
-function dueForLastSeen(projectId: string, key: string, nowMs: number): boolean {
-  const k = `${projectId}:${key}`;
+function dueForLastSeen(deviceId: string, key: string, nowMs: number): boolean {
+  const k = `${deviceId}:${key}`;
   const prev = lastSeenWrites.get(k);
   if (prev !== undefined && nowMs - prev < LAST_SEEN_THROTTLE_MS) return false;
   lastSeenWrites.set(k, nowMs);
@@ -27,11 +27,12 @@ function dueForLastSeen(projectId: string, key: string, nowMs: number): boolean 
 export async function upsertVariables(
   env: Env,
   projectId: string,
+  deviceId: string,
   keys: string[],
   now: number
 ): Promise<void> {
   const nowMs = Date.now();
-  const due = [...new Set(keys)].filter((key) => dueForLastSeen(projectId, key, nowMs));
+  const due = [...new Set(keys)].filter((key) => dueForLastSeen(deviceId, key, nowMs));
   if (due.length === 0) return;
   try {
     // Existing keys only refresh last_seen; new keys count against the cap. Chunk the
@@ -40,8 +41,8 @@ export async function upsertVariables(
     for (const part of chunk(due, MAX_BOUND_PARAMS - 1)) {
       const placeholders = part.map(() => '?').join(',');
       const rows = await env.DB
-        .prepare(`SELECT key FROM project_variables WHERE project_id = ? AND key IN (${placeholders})`)
-        .bind(projectId, ...part)
+        .prepare(`SELECT key FROM project_variables WHERE device_id = ? AND key IN (${placeholders})`)
+        .bind(deviceId, ...part)
         .all<{ key: string }>();
       for (const r of rows.results) existing.add(r.key);
     }
@@ -61,15 +62,15 @@ export async function upsertVariables(
       keysToWrite.map((key) =>
         env.DB
           .prepare(
-            `INSERT INTO project_variables (id, project_id, key, created_at, updated_at, last_seen)
-             VALUES (?, ?, ?, ?, ?, ?)
-             ON CONFLICT(project_id, key) DO UPDATE SET last_seen = excluded.last_seen`
+            `INSERT INTO project_variables (id, project_id, device_id, key, created_at, updated_at, last_seen)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(project_id, device_id, key) DO UPDATE SET last_seen = excluded.last_seen`
           )
-          .bind(newId('variable'), projectId, key, now, now, now)
+          .bind(newId('variable'), projectId, deviceId, key, now, now, now)
       )
     );
   } catch {
     // Best-effort — never fail telemetry on it. Clear stamps so a failed write retries next ingest.
-    for (const key of due) lastSeenWrites.delete(`${projectId}:${key}`);
+    for (const key of due) lastSeenWrites.delete(`${deviceId}:${key}`);
   }
 }

--- a/worker/src/domains/telemetry/ws-protocol.ts
+++ b/worker/src/domains/telemetry/ws-protocol.ts
@@ -5,6 +5,7 @@ import { parseTelemetryBody } from './validate';
 import type { IngestPoint } from '../../platform/durable-objects/project-do';
 
 export type DeviceMessage =
+  | { kind: 'hello'; device: string; chip?: string; firmware?: string }
   | { kind: 'ack'; ids: string[] }
   | { kind: 'telemetry'; points: IngestPoint[] }
   | { kind: 'event'; event: string; payload?: Record<string, unknown> }
@@ -24,6 +25,13 @@ export function parseDeviceMessage(raw: string): DeviceMessage {
   const m = msg as Record<string, unknown>;
 
   switch (m.type) {
+    case 'hello': {
+      const device = typeof m.device === 'string' ? m.device.trim() : '';
+      if (!device) return { kind: 'ignore' };
+      const chip = typeof m.chip === 'string' ? m.chip.slice(0, 32) : undefined;
+      const firmware = typeof m.firmware === 'string' ? m.firmware.slice(0, 32) : undefined;
+      return { kind: 'hello', device, ...(chip ? { chip } : {}), ...(firmware ? { firmware } : {}) };
+    }
     case 'ack': {
       const ids = Array.isArray(m.ids) ? m.ids.filter((x): x is string => typeof x === 'string') : [];
       return { kind: 'ack', ids };

--- a/worker/src/domains/variables/routes.ts
+++ b/worker/src/domains/variables/routes.ts
@@ -6,6 +6,7 @@ import { newId } from '../../platform/lib/ids';
 import { generateToken } from '../../platform/lib/tokens';
 import { recordAudit } from '../../platform/lib/audit';
 import { projectStub } from '../../platform/durable-objects/stubs';
+import { storageIdOf } from '../devices/service';
 import { createVariable, updateVariable, listVariables } from './service';
 import { actorFromSession, serviceErrorResponse } from '../../platform/lib/service';
 
@@ -59,13 +60,15 @@ variables.delete('/:id', async (c) => {
   const id = c.req.param('id');
 
   const v = await c.env.DB
-    .prepare(`SELECT key FROM project_variables WHERE id = ? AND project_id = ?`)
+    .prepare(`SELECT key, device_id FROM project_variables WHERE id = ? AND project_id = ?`)
     .bind(id, project.id)
-    .first<{ key: string }>();
+    .first<{ key: string; device_id: string }>();
   if (!v) return c.json({ error: 'not_found' }, 404);
 
   try {
-    await projectStub(c.env, project.id).deleteVariable(v.key);
+    // Scoped, or deleting one device's copy would clear the key on all of them.
+    const storageId = await storageIdOf(c.env, project.id, v.device_id);
+    await projectStub(c.env, project.id).deleteVariable(v.key, storageId);
   } catch (e) {
     console.error('variable hot-state delete failed', id, e);
   }

--- a/worker/src/domains/variables/service.ts
+++ b/worker/src/domains/variables/service.ts
@@ -4,7 +4,7 @@ import { recordAudit } from '../../platform/lib/audit';
 import { projectStub } from '../../platform/durable-objects/stubs';
 import { type Actor, ServiceError } from '../../platform/lib/service';
 import { assertProjectAccess } from '../projects/service';
-import { defaultDeviceId } from '../devices/service';
+import { defaultDeviceId, listDevices } from '../devices/service';
 
 export type VariableSummary = {
   id: string;
@@ -28,13 +28,27 @@ export async function listVariables(env: Env, projectId: string): Promise<Variab
 }
 
 export type StateEntry = { value: unknown; received_at: number };
+export type DeviceState = { id: string; name: string; variables: Record<string, StateEntry> };
 
-// Latest value of every variable. Mirrors GET /v1/projects/:proj/state.
-export async function getState(env: Env, projectId: string): Promise<Record<string, StateEntry>> {
-  const latest = await projectStub(env, projectId).getLatestState();
-  const out: Record<string, StateEntry> = {};
-  for (const r of latest) out[r.variable] = { value: r.value, received_at: r.received_at };
-  return out;
+// Mirrors GET /v1/projects/:proj/state. Grouped by device because two of them
+// may report the same key, and a flat map would drop one.
+export async function getState(env: Env, projectId: string): Promise<DeviceState[]> {
+  const [latest, devices] = await Promise.all([
+    projectStub(env, projectId).getLatestState(),
+    listDevices(env, projectId),
+  ]);
+  const fallback = devices.find((d) => d.is_default)?.id;
+  const byDevice = new Map<string, DeviceState>();
+  for (const d of devices) byDevice.set(d.id, { id: d.id, name: d.name, variables: {} });
+
+  for (const r of latest) {
+    // The DO marks the default device '' so it never had to backfill.
+    const id = r.device_id || fallback;
+    if (!id) continue;
+    const bucket = byDevice.get(id);
+    if (bucket) bucket.variables[r.variable] = { value: r.value, received_at: r.received_at };
+  }
+  return [...byDevice.values()];
 }
 
 // Recent points from the Project DO ring buffer (never R2). Mirrors
@@ -69,8 +83,7 @@ export async function createVariable(
 
   const id = newId('variable');
   const now = Math.floor(Date.now() / 1000);
-  // Hand-declared variables belong to the default device; a board that reports
-  // the same key under its own identity gets its own row.
+  // Hand-declared variables belong to the default device.
   const deviceId = await defaultDeviceId(env, projectId);
   if (!deviceId) throw new ServiceError('not_found', 'project has no default device', 'no_default_device');
   try {

--- a/worker/src/domains/variables/service.ts
+++ b/worker/src/domains/variables/service.ts
@@ -4,6 +4,7 @@ import { recordAudit } from '../../platform/lib/audit';
 import { projectStub } from '../../platform/durable-objects/stubs';
 import { type Actor, ServiceError } from '../../platform/lib/service';
 import { assertProjectAccess } from '../projects/service';
+import { defaultDeviceId } from '../devices/service';
 
 export type VariableSummary = {
   id: string;
@@ -68,13 +69,17 @@ export async function createVariable(
 
   const id = newId('variable');
   const now = Math.floor(Date.now() / 1000);
+  // Hand-declared variables belong to the default device; a board that reports
+  // the same key under its own identity gets its own row.
+  const deviceId = await defaultDeviceId(env, projectId);
+  if (!deviceId) throw new ServiceError('not_found', 'project has no default device', 'no_default_device');
   try {
     await env.DB
       .prepare(
-        `INSERT INTO project_variables (id, project_id, key, unit, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?)`
+        `INSERT INTO project_variables (id, project_id, device_id, key, unit, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
       )
-      .bind(id, projectId, key, input.unit ?? null, now, now)
+      .bind(id, projectId, deviceId, key, input.unit ?? null, now, now)
       .run();
   } catch {
     throw new ServiceError('conflict', 'a variable with this key already exists', 'duplicate_key');

--- a/worker/src/domains/variables/service.ts
+++ b/worker/src/domains/variables/service.ts
@@ -4,7 +4,7 @@ import { recordAudit } from '../../platform/lib/audit';
 import { projectStub } from '../../platform/durable-objects/stubs';
 import { type Actor, ServiceError } from '../../platform/lib/service';
 import { assertProjectAccess } from '../projects/service';
-import { defaultDeviceId, listDevices } from '../devices/service';
+import { defaultDeviceId, listDevices, storageIdOf } from '../devices/service';
 
 export type VariableSummary = {
   id: string;
@@ -56,7 +56,8 @@ export async function getSeries(
   env: Env,
   projectId: string,
   variable: string,
-  windowStr: string
+  windowStr: string,
+  deviceId?: string | null
 ): Promise<{ window: string; points: unknown[] }> {
   const now = Math.floor(Date.now() / 1000);
   const m = /^(\d+)([smh])$/.exec(windowStr);
@@ -65,7 +66,9 @@ export async function getSeries(
     const n = Number(m[1]);
     seconds = m[2] === 'h' ? n * 3600 : m[2] === 'm' ? n * 60 : n;
   }
-  const points = await projectStub(env, projectId).getSeries(variable, now - seconds);
+  // No device reads the whole project — what a single-device instance always did.
+  const storageId = deviceId ? await storageIdOf(env, projectId, deviceId) : null;
+  const points = await projectStub(env, projectId).getSeries(variable, now - seconds, storageId);
   return { window: m ? windowStr : '1h', points };
 }
 
@@ -148,22 +151,24 @@ export async function setVariableControl(
   env: Env,
   actor: Actor,
   projectId: string,
-  input: { variable: string; value: unknown }
+  input: { variable: string; value: unknown; device?: string | null }
 ): Promise<{ id: string; variable: string; value: unknown }> {
   await assertProjectAccess(env, actor, projectId);
   const variable = (input.variable ?? '').trim();
   if (!variable) throw new ServiceError('bad_request', 'variable is required', 'missing_variable');
+  const deviceId = input.device ?? (await defaultDeviceId(env, projectId));
 
   // The variable must already exist in the project (mirrors the dashboard
   // control path, which refuses variable_not_in_project).
   const exists = await env.DB
-    .prepare(`SELECT 1 AS ok FROM project_variables WHERE project_id = ? AND key = ?`)
-    .bind(projectId, variable)
+    .prepare(`SELECT 1 AS ok FROM project_variables WHERE project_id = ? AND device_id = ? AND key = ?`)
+    .bind(projectId, deviceId, variable)
     .first<{ ok: number }>();
   if (!exists) throw new ServiceError('not_found', 'variable not in project', 'variable_not_in_project');
 
   const id = newId('control');
-  await projectStub(env, projectId).addControl(id, variable, input.value ?? null);
+  const storageId = await storageIdOf(env, projectId, deviceId!);
+  await projectStub(env, projectId).addControl(id, variable, input.value ?? null, storageId);
 
   await recordAudit(env, {
     projectId,

--- a/worker/src/mcp/tools-read.ts
+++ b/worker/src/mcp/tools-read.ts
@@ -93,6 +93,7 @@ export function registerReadTools(server: McpServer, env: Env, props: McpProps):
       inputSchema: {
         project: project.optional(),
         variable: z.string().describe('Variable key.'),
+        device: z.string().optional().describe('Device id. Omit to read across every device.'),
         window: z
           .string()
           .regex(/^\d+[smh]$/)
@@ -104,7 +105,7 @@ export function registerReadTools(server: McpServer, env: Env, props: McpProps):
     (args) =>
       run(async () => {
         const pid = await resolveProjectId(env, props, args.project);
-        const { window, points } = await getSeries(env, pid, args.variable, args.window ?? '1h');
+        const { window, points } = await getSeries(env, pid, args.variable, args.window ?? '1h', args.device);
         return { project: pid, variable: args.variable, window, points };
       })
   );

--- a/worker/src/mcp/tools-write.ts
+++ b/worker/src/mcp/tools-write.ts
@@ -71,10 +71,18 @@ export function registerWriteTools(server: McpServer, env: Env, props: McpProps)
       inputSchema: {
         project,
         variable: z.string().describe('Variable key.'),
+        device: z.string().optional().describe("Device id. Omit for the project's default device."),
         value: z.any().describe('Value to send (number, boolean, string, or JSON).'),
       },
     },
-    (args) => run(() => setVariableControl(env, actor(), scopeProjectId(props, args.project), { variable: args.variable, value: args.value }))
+    (args) =>
+      run(() =>
+        setVariableControl(env, actor(), scopeProjectId(props, args.project), {
+          variable: args.variable,
+          value: args.value,
+          device: args.device ?? null,
+        })
+      )
   );
 
   server.registerTool(

--- a/worker/src/platform/db/auto-migrate.ts
+++ b/worker/src/platform/db/auto-migrate.ts
@@ -1,17 +1,13 @@
-// Auto-migrator. On the first request after a deploy, applies any bundled
-// migrations (worker/src/db/migrations/*.sql, baked into migrations.gen.ts) that
-// haven't run yet, tracked in the d1_migrations table.
+// Auto-migrator. On the first request after a deploy, applies bundled migrations
+// that haven't run yet, tracked in d1_migrations.
 //
-// nodrix is pre-alpha: there's a single baseline migration and instances are
-// recreated fresh, so there's no legacy-baseline handling — just "apply what's
-// missing, in order." Concurrent isolates are guarded by an INSERT OR IGNORE
-// claim; a crash mid-migration leaves applied_at=0, which the next run retries.
+// One db.batch() per migration: D1 runs it as a single transaction, so a failure
+// part-way leaves the database untouched. exec() — which D1's migration docs
+// recommend — stops on error without rolling back.
 
 import type { D1Database } from '@cloudflare/workers-types';
 import { MIGRATIONS } from './migrations.gen';
 
-// Module-level guard: at most one migration check per Worker isolate. If it
-// failed we null it out so the next request retries.
 let inFlight: Promise<void> | null = null;
 
 export function ensureMigrated(db: D1Database): Promise<void> {
@@ -40,8 +36,8 @@ async function applyMigrations(db: D1Database): Promise<void> {
     .all<{ name: string; applied_at: number }>();
   const applied = new Set(res.results.filter((r) => r.applied_at > 0).map((r) => r.name));
 
-  // Recover claims that never completed (worker crashed mid-migration) so the
-  // loop below retries them from scratch.
+  // applied_at = 0 means the batch rolled back; releasing the claim is the
+  // whole of the recovery.
   for (const r of res.results) {
     if (r.applied_at === 0) {
       await db.prepare(`DELETE FROM d1_migrations WHERE name = ? AND applied_at = 0`).bind(r.name).run();
@@ -51,8 +47,7 @@ async function applyMigrations(db: D1Database): Promise<void> {
   for (const m of MIGRATIONS) {
     if (applied.has(m.name)) continue;
 
-    // Claim first — INSERT OR IGNORE keeps two concurrent isolates from running
-    // the same DDL twice (second one's changes count is 0, so it skips).
+    // INSERT OR IGNORE keeps two concurrent isolates from running the same DDL.
     const claim = await db
       .prepare(`INSERT OR IGNORE INTO d1_migrations (name, applied_at) VALUES (?, 0)`)
       .bind(m.name)
@@ -61,14 +56,14 @@ async function applyMigrations(db: D1Database): Promise<void> {
 
     console.log(`[migrate] applying ${m.name} (${m.statements.length} statements)`);
     try {
-      for (const stmt of m.statements) await db.prepare(stmt).run();
-      await db
-        .prepare(`UPDATE d1_migrations SET applied_at = ? WHERE name = ?`)
-        .bind(Math.floor(Date.now() / 1000), m.name)
-        .run();
+      await db.batch([
+        ...m.statements.map((s) => db.prepare(s)),
+        db
+          .prepare(`UPDATE d1_migrations SET applied_at = ? WHERE name = ?`)
+          .bind(Math.floor(Date.now() / 1000), m.name),
+      ]);
       console.log(`[migrate] applied ${m.name}`);
     } catch (e) {
-      // Roll back the claim so we retry on a later request.
       await db.prepare(`DELETE FROM d1_migrations WHERE name = ? AND applied_at = 0`).bind(m.name).run();
       throw e;
     }

--- a/worker/src/platform/db/migrations.gen.ts
+++ b/worker/src/platform/db/migrations.gen.ts
@@ -47,5 +47,19 @@ export const MIGRATIONS: Migration[] = [
       "CREATE INDEX IF NOT EXISTS idx_invites_email ON invites(email) WHERE email IS NOT NULL",
       "CREATE TABLE IF NOT EXISTS invite_projects (\n  invite_id  TEXT NOT NULL REFERENCES invites(id) ON DELETE CASCADE,\n  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,\n  PRIMARY KEY (invite_id, project_id)\n)"
     ]
+  },
+  {
+    "name": "0002_devices",
+    "statements": [
+      "CREATE TABLE IF NOT EXISTS devices (\n  id               TEXT PRIMARY KEY,\n  project_id       TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,\n  name             TEXT NOT NULL,\n  chip             TEXT,\n  firmware_version TEXT,\n  is_default       INTEGER NOT NULL DEFAULT 0,\n  first_seen       INTEGER,\n  last_seen        INTEGER,\n  created_at       INTEGER NOT NULL\n)",
+      "CREATE INDEX IF NOT EXISTS idx_devices_project ON devices(project_id)",
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_default\n  ON devices(project_id) WHERE is_default = 1",
+      "INSERT INTO devices (id, project_id, name, is_default, created_at)\nSELECT 'dev_' || substr(p.id, 5), p.id, 'Default', 1, p.created_at\nFROM projects p\nWHERE NOT EXISTS (SELECT 1 FROM devices d WHERE d.project_id = p.id AND d.is_default = 1)",
+      "CREATE TABLE project_variables_new (\n  id          TEXT PRIMARY KEY,\n  project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,\n  device_id   TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,\n  key         TEXT NOT NULL,\n  unit        TEXT,\n  created_at  INTEGER NOT NULL,\n  updated_at  INTEGER NOT NULL,\n  last_seen   INTEGER\n)",
+      "INSERT INTO project_variables_new (id, project_id, device_id, key, unit, created_at, updated_at, last_seen)\nSELECT v.id, v.project_id, d.id, v.key, v.unit, v.created_at, v.updated_at, v.last_seen\nFROM project_variables v\nJOIN devices d ON d.project_id = v.project_id AND d.is_default = 1",
+      "DROP TABLE project_variables",
+      "ALTER TABLE project_variables_new RENAME TO project_variables",
+      "CREATE UNIQUE INDEX idx_project_variables_key\n  ON project_variables(project_id, device_id, key)"
+    ]
   }
 ];

--- a/worker/src/platform/db/migrations.gen.ts
+++ b/worker/src/platform/db/migrations.gen.ts
@@ -51,8 +51,9 @@ export const MIGRATIONS: Migration[] = [
   {
     "name": "0002_devices",
     "statements": [
-      "CREATE TABLE IF NOT EXISTS devices (\n  id               TEXT PRIMARY KEY,\n  project_id       TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,\n  name             TEXT NOT NULL,\n  chip             TEXT,\n  firmware_version TEXT,\n  is_default       INTEGER NOT NULL DEFAULT 0,\n  first_seen       INTEGER,\n  last_seen        INTEGER,\n  created_at       INTEGER NOT NULL\n)",
+      "CREATE TABLE IF NOT EXISTS devices (\n  id               TEXT PRIMARY KEY,\n  project_id       TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,\n  name             TEXT NOT NULL,\n  device_key       TEXT,\n  chip             TEXT,\n  firmware_version TEXT,\n  is_default       INTEGER NOT NULL DEFAULT 0,\n  first_seen       INTEGER,\n  last_seen        INTEGER,\n  created_at       INTEGER NOT NULL\n)",
       "CREATE INDEX IF NOT EXISTS idx_devices_project ON devices(project_id)",
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_key\n  ON devices(project_id, device_key) WHERE device_key IS NOT NULL",
       "CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_default\n  ON devices(project_id) WHERE is_default = 1",
       "INSERT INTO devices (id, project_id, name, is_default, created_at)\nSELECT 'dev_' || substr(p.id, 5), p.id, 'Default', 1, p.created_at\nFROM projects p\nWHERE NOT EXISTS (SELECT 1 FROM devices d WHERE d.project_id = p.id AND d.is_default = 1)",
       "CREATE TABLE project_variables_new (\n  id          TEXT PRIMARY KEY,\n  project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,\n  device_id   TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,\n  key         TEXT NOT NULL,\n  unit        TEXT,\n  created_at  INTEGER NOT NULL,\n  updated_at  INTEGER NOT NULL,\n  last_seen   INTEGER\n)",

--- a/worker/src/platform/db/migrations.gen.ts
+++ b/worker/src/platform/db/migrations.gen.ts
@@ -60,7 +60,13 @@ export const MIGRATIONS: Migration[] = [
       "INSERT INTO project_variables_new (id, project_id, device_id, key, unit, created_at, updated_at, last_seen)\nSELECT v.id, v.project_id, d.id, v.key, v.unit, v.created_at, v.updated_at, v.last_seen\nFROM project_variables v\nJOIN devices d ON d.project_id = v.project_id AND d.is_default = 1",
       "DROP TABLE project_variables",
       "ALTER TABLE project_variables_new RENAME TO project_variables",
-      "CREATE UNIQUE INDEX idx_project_variables_key\n  ON project_variables(project_id, device_id, key)"
+      "CREATE UNIQUE INDEX idx_project_variables_key\n  ON project_variables(project_id, device_id, key)",
+      "CREATE TABLE IF NOT EXISTS firmware (\n  id          TEXT PRIMARY KEY,\n  project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,\n  version     TEXT NOT NULL,\n  target      TEXT,\n  size        INTEGER NOT NULL,\n  sha256      TEXT NOT NULL,\n  r2_key      TEXT NOT NULL,\n  notes       TEXT,\n  created_by  TEXT REFERENCES users(id),\n  created_at  INTEGER NOT NULL\n)",
+      "CREATE INDEX IF NOT EXISTS idx_firmware_project ON firmware(project_id, created_at DESC)",
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_firmware_version ON firmware(project_id, version)",
+      "ALTER TABLE devices ADD COLUMN desired_firmware_id TEXT REFERENCES firmware(id) ON DELETE SET NULL",
+      "ALTER TABLE devices ADD COLUMN ota_status TEXT",
+      "ALTER TABLE devices ADD COLUMN ota_updated_at INTEGER"
     ]
   }
 ];

--- a/worker/src/platform/db/migrations/0002_devices.sql
+++ b/worker/src/platform/db/migrations/0002_devices.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS devices (
   id               TEXT PRIMARY KEY,
   project_id       TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
   name             TEXT NOT NULL,
+  device_key       TEXT,
   chip             TEXT,
   firmware_version TEXT,
   is_default       INTEGER NOT NULL DEFAULT 0,
@@ -11,6 +12,11 @@ CREATE TABLE IF NOT EXISTS devices (
   created_at       INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_devices_project ON devices(project_id);
+
+-- What the board calls itself, kept apart from the id so renaming is free and a
+-- MAC never leaks into anything a user reads. NULL on the default device.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_key
+  ON devices(project_id, device_key) WHERE device_key IS NOT NULL;
 
 -- Exactly one default per project, enforced rather than assumed.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_default

--- a/worker/src/platform/db/migrations/0002_devices.sql
+++ b/worker/src/platform/db/migrations/0002_devices.sql
@@ -52,3 +52,26 @@ ALTER TABLE project_variables_new RENAME TO project_variables;
 
 CREATE UNIQUE INDEX idx_project_variables_key
   ON project_variables(project_id, device_id, key);
+
+-- Firmware uploaded to this instance. The image itself lives in R2; this is the
+-- metadata the dashboard and the update check read.
+CREATE TABLE IF NOT EXISTS firmware (
+  id          TEXT PRIMARY KEY,
+  project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  version     TEXT NOT NULL,
+  target      TEXT,
+  size        INTEGER NOT NULL,
+  sha256      TEXT NOT NULL,
+  r2_key      TEXT NOT NULL,
+  notes       TEXT,
+  created_by  TEXT REFERENCES users(id),
+  created_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_firmware_project ON firmware(project_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_firmware_version ON firmware(project_id, version);
+
+-- Desired state. A device compares its own version against this and pulls when
+-- they differ; nothing pushes an image at a device.
+ALTER TABLE devices ADD COLUMN desired_firmware_id TEXT REFERENCES firmware(id) ON DELETE SET NULL;
+ALTER TABLE devices ADD COLUMN ota_status TEXT;
+ALTER TABLE devices ADD COLUMN ota_updated_at INTEGER;

--- a/worker/src/platform/db/migrations/0002_devices.sql
+++ b/worker/src/platform/db/migrations/0002_devices.sql
@@ -1,0 +1,48 @@
+-- Devices. Rows appear the first time a board is seen; there is no enrolment.
+CREATE TABLE IF NOT EXISTS devices (
+  id               TEXT PRIMARY KEY,
+  project_id       TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name             TEXT NOT NULL,
+  chip             TEXT,
+  firmware_version TEXT,
+  is_default       INTEGER NOT NULL DEFAULT 0,
+  first_seen       INTEGER,
+  last_seen        INTEGER,
+  created_at       INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_devices_project ON devices(project_id);
+
+-- Exactly one default per project, enforced rather than assumed.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_default
+  ON devices(project_id) WHERE is_default = 1;
+
+-- Every project gets a default device. Telemetry that names no device lands
+-- here, so a plain curl with only a token keeps working.
+INSERT INTO devices (id, project_id, name, is_default, created_at)
+SELECT 'dev_' || substr(p.id, 5), p.id, 'Default', 1, p.created_at
+FROM projects p
+WHERE NOT EXISTS (SELECT 1 FROM devices d WHERE d.project_id = p.id AND d.is_default = 1);
+
+-- project_variables gains device_id. Rebuilt rather than altered: the column is
+-- NOT NULL with a foreign key, and the unique key it belongs to changes shape.
+CREATE TABLE project_variables_new (
+  id          TEXT PRIMARY KEY,
+  project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  device_id   TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  key         TEXT NOT NULL,
+  unit        TEXT,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL,
+  last_seen   INTEGER
+);
+
+INSERT INTO project_variables_new (id, project_id, device_id, key, unit, created_at, updated_at, last_seen)
+SELECT v.id, v.project_id, d.id, v.key, v.unit, v.created_at, v.updated_at, v.last_seen
+FROM project_variables v
+JOIN devices d ON d.project_id = v.project_id AND d.is_default = 1;
+
+DROP TABLE project_variables;
+ALTER TABLE project_variables_new RENAME TO project_variables;
+
+CREATE UNIQUE INDEX idx_project_variables_key
+  ON project_variables(project_id, device_id, key);

--- a/worker/src/platform/durable-objects/dashboard-do.ts
+++ b/worker/src/platform/durable-objects/dashboard-do.ts
@@ -4,6 +4,7 @@ import { projectStub } from './stubs';
 import { validateLayout, variablesFromLayout, chartVariablesFromLayout, type Layout } from '../lib/layout';
 import { newId } from '../lib/ids';
 import { userCanAccessProject } from '../lib/roles';
+import { storageIdOf } from '../../domains/devices/service';
 import type { CompactSeries } from '../lib/series';
 import { migrateSchema, type SchemaStep } from './schema';
 
@@ -179,6 +180,9 @@ export class DashboardDO extends DurableObject<Env> {
     await this.subscribe(row.project_id).catch(() => undefined);
 
     const stub = projectStub(this.env, row.project_id);
+    const snapshotDevice = layout.device
+      ? await storageIdOf(this.env, row.project_id, layout.device)
+      : '';
 
     // Only ship what this dashboard renders: latest state for referenced
     // variables + 1h series for chart variables (not the whole project history).
@@ -195,7 +199,7 @@ export class DashboardDO extends DurableObject<Env> {
     // One DO round trip (chartVars=[] skips the series query inside the DO).
     const { latest, series, oldestTs } = await stub
       // Widgets bind to a bare key, so a second device would merge into the chart.
-      .getDashboardSnapshot(chartVars, fromTs, cap, '')
+      .getDashboardSnapshot(chartVars, fromTs, cap, snapshotDevice)
       .catch(() => ({ latest: [], series: {} as CompactSeries, oldestTs: null as number | null }));
 
     const variables: Record<string, { value: unknown; received_at: number }> = {};

--- a/worker/src/platform/durable-objects/dashboard-do.ts
+++ b/worker/src/platform/durable-objects/dashboard-do.ts
@@ -194,7 +194,8 @@ export class DashboardDO extends DurableObject<Env> {
 
     // One DO round trip (chartVars=[] skips the series query inside the DO).
     const { latest, series, oldestTs } = await stub
-      .getDashboardSnapshot(chartVars, fromTs, cap)
+      // Widgets bind to a bare key, so a second device would merge into the chart.
+      .getDashboardSnapshot(chartVars, fromTs, cap, '')
       .catch(() => ({ latest: [], series: {} as CompactSeries, oldestTs: null as number | null }));
 
     const variables: Record<string, { value: unknown; received_at: number }> = {};

--- a/worker/src/platform/durable-objects/dashboard-do.ts
+++ b/worker/src/platform/durable-objects/dashboard-do.ts
@@ -5,6 +5,7 @@ import { validateLayout, variablesFromLayout, chartVariablesFromLayout, type Lay
 import { newId } from '../lib/ids';
 import { userCanAccessProject } from '../lib/roles';
 import type { CompactSeries } from '../lib/series';
+import { migrateSchema, type SchemaStep } from './schema';
 
 // Cap on points per chart series in the bootstrap snapshot (mirrors the public
 // /state full snapshot). Dense ingest is stride-sampled to this.
@@ -41,13 +42,23 @@ type AckMsg = { type: 'ack'; req: string; ok: boolean; reason?: string };
 type ClientMsg =
   | { type: 'control'; req?: string; variable: string; value?: unknown };
 
+const SCHEMA: SchemaStep[] = [
+  (sql) => {
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS subscribed_project (
+        project_id TEXT PRIMARY KEY
+      );
+    `);
+  },
+];
+
 export class DashboardDO extends DurableObject<Env> {
   private sql: SqlStorage;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
-    this.initSchema();
+    migrateSchema(ctx, SCHEMA);
   }
 
   override async fetch(request: Request): Promise<Response> {
@@ -274,13 +285,5 @@ export class DashboardDO extends DurableObject<Env> {
       })
     );
     this.sql.exec(`DELETE FROM subscribed_project`);
-  }
-
-  private initSchema(): void {
-    this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS subscribed_project (
-        project_id TEXT PRIMARY KEY
-      );
-    `);
   }
 }

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -631,22 +631,21 @@ export class ProjectDO extends DurableObject<Env> {
     // Same as close: nothing to do.
   }
 
-  // Wipes all data owned by this project — DO SQLite + R2 telemetry history.
+  // Wipes all data owned by this project — DO SQLite + everything it owns in R2.
   async destroy(): Promise<void> {
     const projectId = this.projectId();
 
-    // Delete every R2 object under telemetry/{projectId}/ (paginated).
-    let cursor: string | undefined;
-    do {
-      const list = await this.env.R2.list({
-        prefix: `telemetry/${projectId}/`,
-        ...(cursor ? { cursor } : {}),
-      });
-      if (list.objects.length > 0) {
-        await this.env.R2.delete(list.objects.map((o) => o.key));
-      }
-      cursor = list.truncated ? list.cursor : undefined;
-    } while (cursor);
+    // A prefix added elsewhere and not listed here leaks objects nothing reaches.
+    for (const prefix of [`telemetry/${projectId}/`, `firmware/${projectId}/`]) {
+      let cursor: string | undefined;
+      do {
+        const list = await this.env.R2.list({ prefix, ...(cursor ? { cursor } : {}) });
+        if (list.objects.length > 0) {
+          await this.env.R2.delete(list.objects.map((o) => o.key));
+        }
+        cursor = list.truncated ? list.cursor : undefined;
+      } while (cursor);
+    }
 
     // Cancel any scheduled flush + wipe SQLite storage entirely.
     await this.ctx.storage.deleteAlarm();

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -10,6 +10,7 @@ import { toCompactSeries, type CompactSeries } from '../lib/series';
 import { chunk, MAX_BOUND_PARAMS } from '../lib/sql';
 import { parseDeviceMessage } from '../../domains/telemetry/ws-protocol';
 import { upsertVariables } from '../../domains/telemetry/variables';
+import { migrateSchema, type SchemaStep } from './schema';
 
 // Project Durable Object (one per project id, SQLite-backed): latest variable
 // state, recent ring buffer, pending control writes, and the R2 flush cursor.
@@ -55,6 +56,56 @@ export type FlushResult = {
   newCursor: number;
 };
 
+const SCHEMA: SchemaStep[] = [
+  (sql) => {
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS latest_state (
+        variable    TEXT PRIMARY KEY,
+        value       TEXT NOT NULL,
+        received_at INTEGER NOT NULL
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS ring_buffer (
+        rowid    INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts       INTEGER NOT NULL,
+        variable TEXT NOT NULL,
+        value    TEXT NOT NULL
+      );
+    `);
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_ts ON ring_buffer(ts);`);
+    // Serves the per-variable series reads (chart snapshots + delta polls); the
+    // ts-only index above stays for age-based eviction.
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_var_ts ON ring_buffer(variable, ts);`);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS pending_control (
+        id           TEXT PRIMARY KEY,
+        variable     TEXT NOT NULL,
+        value        TEXT NOT NULL,
+        created_at   INTEGER NOT NULL,
+        delivered_at INTEGER
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS flush_meta (
+        k TEXT PRIMARY KEY,
+        v TEXT
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS subscriptions (
+        dashboard_id TEXT PRIMARY KEY
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS auto_cache (
+        k TEXT PRIMARY KEY,
+        v TEXT
+      );
+    `);
+  },
+];
+
 export class ProjectDO extends DurableObject<Env> {
   private sql: SqlStorage;
   private projectId(): string {
@@ -68,7 +119,7 @@ export class ProjectDO extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
-    this.initSchema();
+    migrateSchema(ctx, SCHEMA);
   }
 
   // WS connect calls this so the DO has its project_id for socket-driven ingest —
@@ -599,56 +650,6 @@ export class ProjectDO extends DurableObject<Env> {
 
     // Flush NEVER deletes ring_buffer rows. Eviction owns that.
     return { flushed: rows.length, keys, newCursor };
-  }
-
-  private initSchema(): void {
-    this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS latest_state (
-        variable    TEXT PRIMARY KEY,
-        value       TEXT NOT NULL,
-        received_at INTEGER NOT NULL
-      );
-    `);
-    this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS ring_buffer (
-        rowid    INTEGER PRIMARY KEY AUTOINCREMENT,
-        ts       INTEGER NOT NULL,
-        variable TEXT NOT NULL,
-        value    TEXT NOT NULL
-      );
-    `);
-    this.sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_ts ON ring_buffer(ts);`);
-    // Serves the per-variable series reads (chart snapshots + delta polls); the
-    // ts-only index above stays for age-based eviction.
-    this.sql.exec(
-      `CREATE INDEX IF NOT EXISTS idx_ring_buffer_var_ts ON ring_buffer(variable, ts);`
-    );
-    this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS pending_control (
-        id           TEXT PRIMARY KEY,
-        variable     TEXT NOT NULL,
-        value        TEXT NOT NULL,
-        created_at   INTEGER NOT NULL,
-        delivered_at INTEGER
-      );
-    `);
-    this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS flush_meta (
-        k TEXT PRIMARY KEY,
-        v TEXT
-      );
-    `);
-    this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS subscriptions (
-        dashboard_id TEXT PRIMARY KEY
-      );
-    `);
-    this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS auto_cache (
-        k TEXT PRIMARY KEY,
-        v TEXT
-      );
-    `);
   }
 
   private evictRingBuffer(now: number): void {

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -30,6 +30,8 @@ const FLUSH_INTERVAL_MS = 60_000;
 const HIGH_WATER_MARK_ROWS = 500;
 // Roughly a megabyte a call, and a boot-looping board would pull it forever.
 const OTA_DOWNLOADS_PER_HOUR = 6;
+// A cold toolchain install can take minutes; a warm build is seconds.
+const BUILD_TIMEOUT_MS = 5 * 60_000;
 // Variable-trigger automations are cached in DO SQLite so high-rate telemetry
 // doesn't read D1 per point. Refreshed when stale or on invalidateAutomations().
 const AUTO_CACHE_TTL_MS = 30_000;
@@ -57,6 +59,10 @@ export type SeriesRow = {
   value: unknown;
 };
 
+export type BuildOutcome =
+  | { ok: true; binary: string; log: string[] }
+  | { ok: false; error: string; log: string[] };
+
 export type FlushResult = {
   flushed: number;
   keys: string[];
@@ -66,6 +72,9 @@ export type FlushResult = {
 
 export class ProjectDO extends DurableObject<Env> {
   private sql: SqlStorage;
+  // Held only while a browser waits on the response, so hibernation can't strand one.
+  private pendingBuilds = new Map<string, { resolve: (r: BuildOutcome) => void; log: string[] }>();
+
   private projectId(): string {
     // Stored on first ingest; used as the R2 key prefix.
     const row = this.sql
@@ -447,6 +456,58 @@ export class ProjectDO extends DurableObject<Env> {
     this.sql.exec(`DELETE FROM pending_control WHERE variable = ? AND device_id IS ?`, variable, deviceId);
   }
 
+  private isAgent(ws: WebSocket): boolean {
+    return (ws.deserializeAttachment() as { role?: string } | null)?.role === 'agent';
+  }
+
+  // Nothing is queued for an agent that isn't connected.
+  async requestBuild(fqbn: string, sketch: string): Promise<BuildOutcome> {
+    const agent = this.ctx.getWebSockets().find((ws) => this.isAgent(ws));
+    if (!agent) return { ok: false, error: 'no_agent', log: [] };
+
+    const id = newId('build');
+    const log: string[] = [];
+    return new Promise<BuildOutcome>((resolve) => {
+      this.pendingBuilds.set(id, { resolve, log });
+      setTimeout(() => {
+        const pending = this.pendingBuilds.get(id);
+        if (!pending) return;
+        this.pendingBuilds.delete(id);
+        pending.resolve({ ok: false, error: 'timed out', log: pending.log });
+      }, BUILD_TIMEOUT_MS);
+      try {
+        agent.send(JSON.stringify({ type: 'build', id, fqbn, sketch }));
+      } catch {
+        this.pendingBuilds.delete(id);
+        resolve({ ok: false, error: 'agent went away', log: [] });
+      }
+    });
+  }
+
+  private handleAgentFrame(raw: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    const build = typeof msg['build'] === 'string' ? msg['build'] : '';
+    const pending = this.pendingBuilds.get(build);
+    if (!pending) return;
+
+    if (msg['type'] === 'log' && typeof msg['line'] === 'string') {
+      if (pending.log.length < 500) pending.log.push(msg['line']);
+      return;
+    }
+    if (msg['type'] !== 'result') return;
+    this.pendingBuilds.delete(build);
+    pending.resolve(
+      msg['ok'] === true && typeof msg['binary'] === 'string'
+        ? { ok: true, binary: msg['binary'], log: pending.log }
+        : { ok: false, error: String(msg['error'] ?? 'build failed'), log: pending.log }
+    );
+  }
+
   // Survives hibernation, unlike anything held in memory.
   private deviceOf(ws: WebSocket): string {
     const att = ws.deserializeAttachment() as { device?: string } | null;
@@ -518,6 +579,11 @@ export class ProjectDO extends DurableObject<Env> {
     const server = pair[1] as WebSocket;
     this.ctx.acceptWebSocket(server);
 
+    if (request.headers.get('x-nodrix-role') === 'agent') {
+      server.serializeAttachment({ role: 'agent' });
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
     // Until a hello arrives the socket counts as the default device.
     server.serializeAttachment({ device: '' });
     this.sendPending(server, `(device_id IS NULL OR device_id = '')`);
@@ -529,6 +595,7 @@ export class ProjectDO extends DurableObject<Env> {
   // parser. Invalid input → error frame; unknown/garbage → dropped.
   override async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
     const raw = typeof message === 'string' ? message : new TextDecoder().decode(message);
+    if (this.isAgent(ws)) return this.handleAgentFrame(raw);
     const msg = parseDeviceMessage(raw);
     switch (msg.kind) {
       case 'hello': {

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -287,10 +287,11 @@ export class ProjectDO extends DurableObject<Env> {
   async getDashboardSnapshot(
     variables: string[],
     sinceTs: number | null,
-    cap?: number
+    cap?: number,
+    deviceId = ''
   ): Promise<{ latest: LatestStateRow[]; series: CompactSeries; oldestTs: number | null }> {
-    const latest = this.getLatestState();
-    const series = this.getSeriesForVariables(variables, sinceTs, cap);
+    const latest = this.getLatestState(deviceId);
+    const series = this.getSeriesForVariables(variables, sinceTs, cap, deviceId);
     return { latest: await latest, series: await series, oldestTs: this.ringOldestTs() };
   }
 
@@ -303,11 +304,13 @@ export class ProjectDO extends DurableObject<Env> {
     return rows[0]?.m ?? null;
   }
 
-  async getLatestState(): Promise<LatestStateRow[]> {
+  async getLatestState(deviceId?: string | null): Promise<LatestStateRow[]> {
     const rows = this.sql
       .exec<{ device_id: string; variable: string; value: string; received_at: number }>(
         `SELECT device_id, variable, value, received_at FROM latest_state
-         ORDER BY device_id ASC, variable ASC`
+         ${deviceId != null ? 'WHERE device_id = ?' : ''}
+         ORDER BY device_id ASC, variable ASC`,
+        ...(deviceId != null ? [deviceId] : [])
       )
       .toArray();
     return rows.map((r) => ({

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -10,6 +10,7 @@ import { toCompactSeries, type CompactSeries } from '../lib/series';
 import { chunk, MAX_BOUND_PARAMS } from '../lib/sql';
 import { parseDeviceMessage } from '../../domains/telemetry/ws-protocol';
 import { upsertVariables } from '../../domains/telemetry/variables';
+import { defaultDeviceId } from '../../domains/devices/service';
 import { migrateSchema, type SchemaStep } from './schema';
 
 // Project Durable Object (one per project id, SQLite-backed): latest variable
@@ -515,7 +516,11 @@ export class ProjectDO extends DurableObject<Env> {
         const pid = this.projectId();
         await this.ingest(pid, msg.points);
         const now = Math.floor(Date.now() / 1000);
-        this.ctx.waitUntil(upsertVariables(this.env, pid, msg.points.map((p) => p.variable), now));
+        this.ctx.waitUntil(
+          defaultDeviceId(this.env, pid).then((deviceId) =>
+            deviceId ? upsertVariables(this.env, pid, deviceId, msg.points.map((p) => p.variable), now) : undefined
+          )
+        );
         return;
       }
       case 'event':

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -26,6 +26,8 @@ const ROWS_PER_4COL_INSERT = Math.floor(MAX_BOUND_PARAMS / 4);
 const EVICT_INTERVAL_SECONDS = 30;
 const FLUSH_INTERVAL_MS = 60_000;
 const HIGH_WATER_MARK_ROWS = 500;
+// Roughly a megabyte a call, and a boot-looping board would pull it forever.
+const OTA_DOWNLOADS_PER_HOUR = 6;
 // Variable-trigger automations are cached in DO SQLite so high-rate telemetry
 // doesn't read D1 per point. Refreshed when stale or on invalidateAutomations().
 const AUTO_CACHE_TTL_MS = 30_000;
@@ -132,6 +134,16 @@ const SCHEMA: SchemaStep[] = [
 
     // NULL device still broadcasts.
     sql.exec(`ALTER TABLE pending_control ADD COLUMN device_id TEXT;`);
+  },
+  (sql) => {
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS ota_quota (
+        device_id TEXT NOT NULL,
+        window    INTEGER NOT NULL,
+        count     INTEGER NOT NULL,
+        PRIMARY KEY (device_id, window)
+      );
+    `);
   },
 ];
 
@@ -535,6 +547,23 @@ export class ProjectDO extends DurableObject<Env> {
         ws.send(JSON.stringify({ type: 'control', id: cmd.id, variable: cmd.variable, value: safeParse(cmd.value) }));
       } catch { /* dead socket; ignore */ }
     }
+  }
+
+  // In DO SQLite, not KV: an eventually consistent counter can be outrun.
+  async consumeOtaQuota(deviceId: string): Promise<boolean> {
+    const window = Math.floor(Date.now() / 1000 / 3600);
+    this.sql.exec(`DELETE FROM ota_quota WHERE window < ?`, window);
+    const row = this.sql
+      .exec<{ count: number }>(`SELECT count FROM ota_quota WHERE device_id = ? AND window = ?`, deviceId, window)
+      .toArray()[0];
+    if ((row?.count ?? 0) >= OTA_DOWNLOADS_PER_HOUR) return false;
+    this.sql.exec(
+      `INSERT INTO ota_quota (device_id, window, count) VALUES (?, ?, 1)
+       ON CONFLICT(device_id, window) DO UPDATE SET count = count + 1`,
+      deviceId,
+      window
+    );
+    return true;
   }
 
   // A nudge, not a push: the device still decides whether to pull.

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -10,7 +10,7 @@ import { toCompactSeries, type CompactSeries } from '../lib/series';
 import { chunk, MAX_BOUND_PARAMS } from '../lib/sql';
 import { parseDeviceMessage } from '../../domains/telemetry/ws-protocol';
 import { upsertVariables } from '../../domains/telemetry/variables';
-import { defaultDeviceId, normaliseDeviceKey, resolveDevice, recordDeviceSeen } from '../../domains/devices/service';
+import { defaultDeviceId, normaliseDeviceKey, resolveDevice, recordDeviceSeen, touchDevice } from '../../domains/devices/service';
 import { reconcile } from '../../domains/firmware/ota';
 import { migrateSchema } from './schema';
 import { PROJECT_SCHEMA } from './project-schema';
@@ -514,6 +514,11 @@ export class ProjectDO extends DurableObject<Env> {
     return typeof att?.device === 'string' ? att.device : '';
   }
 
+  // The attachment holds a storage id; '' has to become a real D1 id.
+  private async d1DeviceId(ws: WebSocket, projectId: string): Promise<string | null> {
+    return this.deviceOf(ws) || (await defaultDeviceId(this.env, projectId));
+  }
+
   private sendPending(ws: WebSocket, where: string, ...binds: unknown[]): void {
     const rows = this.sql
       .exec<{ id: string; variable: string; value: string }>(
@@ -619,8 +624,13 @@ export class ProjectDO extends DurableObject<Env> {
         await this.ingest(pid, msg.points, this.deviceOf(ws));
         const now = Math.floor(Date.now() / 1000);
         this.ctx.waitUntil(
-          defaultDeviceId(this.env, pid).then((deviceId) =>
-            deviceId ? upsertVariables(this.env, pid, deviceId, msg.points.map((p) => p.variable), now) : undefined
+          this.d1DeviceId(ws, pid).then((id) =>
+            id
+              ? Promise.all([
+                  upsertVariables(this.env, pid, id, msg.points.map((p) => p.variable), now),
+                  touchDevice(this.env, id),
+                ])
+              : undefined
           )
         );
         return;

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -10,7 +10,7 @@ import { toCompactSeries, type CompactSeries } from '../lib/series';
 import { chunk, MAX_BOUND_PARAMS } from '../lib/sql';
 import { parseDeviceMessage } from '../../domains/telemetry/ws-protocol';
 import { upsertVariables } from '../../domains/telemetry/variables';
-import { defaultDeviceId } from '../../domains/devices/service';
+import { defaultDeviceId, normaliseDeviceKey, resolveDevice, recordDeviceSeen } from '../../domains/devices/service';
 import { migrateSchema, type SchemaStep } from './schema';
 
 // Project Durable Object (one per project id, SQLite-backed): latest variable
@@ -440,21 +440,23 @@ export class ProjectDO extends DurableObject<Env> {
     this.sql.exec(`DELETE FROM subscriptions WHERE dashboard_id = ?`, dashboardId);
   }
 
-  async addControl(id: string, variable: string, value: unknown): Promise<void> {
+  async addControl(id: string, variable: string, value: unknown, deviceId: string | null = null): Promise<void> {
     const now = Math.floor(Date.now() / 1000);
     this.sql.exec(
-      `INSERT INTO pending_control (id, variable, value, created_at, delivered_at)
-       VALUES (?, ?, ?, ?, NULL)`,
+      `INSERT INTO pending_control (id, variable, value, created_at, delivered_at, device_id)
+       VALUES (?, ?, ?, ?, NULL, ?)`,
       id,
       variable,
       JSON.stringify(value),
-      now
+      now,
+      deviceId
     );
 
-    // Push to any connected hardware WS clients. If offline, the write stays in
-    // pending_control and is flushed on next connect.
+    // Push to connected hardware. If offline, the write stays in pending_control
+    // and is flushed on next connect.
     const payload = JSON.stringify({ type: 'control', id, variable, value });
     for (const ws of this.ctx.getWebSockets()) {
+      if (deviceId !== null && this.deviceOf(ws) !== deviceId) continue;
       try { ws.send(payload); } catch { /* dead socket; ignore */ }
     }
 
@@ -499,6 +501,28 @@ export class ProjectDO extends DurableObject<Env> {
     this.sql.exec(`DELETE FROM pending_control WHERE variable = ? AND device_id IS ?`, variable, deviceId);
   }
 
+  // Survives hibernation, unlike anything held in memory.
+  private deviceOf(ws: WebSocket): string {
+    const att = ws.deserializeAttachment() as { device?: string } | null;
+    return typeof att?.device === 'string' ? att.device : '';
+  }
+
+  private sendPending(ws: WebSocket, where: string, ...binds: unknown[]): void {
+    const rows = this.sql
+      .exec<{ id: string; variable: string; value: string }>(
+        `SELECT id, variable, value FROM pending_control
+          WHERE delivered_at IS NULL AND ${where}
+          ORDER BY created_at ASC`,
+        ...binds
+      )
+      .toArray();
+    for (const cmd of rows) {
+      try {
+        ws.send(JSON.stringify({ type: 'control', id: cmd.id, variable: cmd.variable, value: safeParse(cmd.value) }));
+      } catch { /* dead socket; ignore */ }
+    }
+  }
+
   async deleteDevice(deviceId: string): Promise<void> {
     this.sql.exec(`DELETE FROM latest_state WHERE device_id = ?`, deviceId);
     this.sql.exec(`DELETE FROM ring_buffer WHERE device_id = ?`, deviceId);
@@ -522,26 +546,9 @@ export class ProjectDO extends DurableObject<Env> {
     const server = pair[1] as WebSocket;
     this.ctx.acceptWebSocket(server);
 
-    // Flush any pending (undelivered) control writes on connect so a device
-    // that missed messages while offline catches up immediately. The device
-    // acks them via `{type:'ack', ids:[...]}` once processed.
-    const pending = this.sql
-      .exec<{ id: string; variable: string; value: string }>(
-        `SELECT id, variable, value FROM pending_control
-          WHERE delivered_at IS NULL
-          ORDER BY created_at ASC`
-      )
-      .toArray();
-    for (const cmd of pending) {
-      try {
-        server.send(JSON.stringify({
-          type: 'control',
-          id: cmd.id,
-          variable: cmd.variable,
-          value: safeParse(cmd.value),
-        }));
-      } catch { /* ignore */ }
-    }
+    // Until a hello arrives the socket counts as the default device.
+    server.serializeAttachment({ device: '' });
+    this.sendPending(server, `(device_id IS NULL OR device_id = '')`);
 
     return new Response(null, { status: 101, webSocket: client });
   }
@@ -552,12 +559,22 @@ export class ProjectDO extends DurableObject<Env> {
     const raw = typeof message === 'string' ? message : new TextDecoder().decode(message);
     const msg = parseDeviceMessage(raw);
     switch (msg.kind) {
+      case 'hello': {
+        const pid = this.projectId();
+        const key = normaliseDeviceKey(msg.device);
+        const device = key ? await resolveDevice(this.env, pid, key, Math.floor(Date.now() / 1000)) : null;
+        if (!device || !device.storageId) return;
+        ws.serializeAttachment({ device: device.storageId });
+        this.ctx.waitUntil(recordDeviceSeen(this.env, device.id, msg.chip, msg.firmware));
+        this.sendPending(ws, `device_id = ?`, device.storageId);
+        return;
+      }
       case 'ack':
         if (msg.ids.length > 0) await this.ackControl(msg.ids);
         return;
       case 'telemetry': {
         const pid = this.projectId();
-        await this.ingest(pid, msg.points);
+        await this.ingest(pid, msg.points, this.deviceOf(ws));
         const now = Math.floor(Date.now() / 1000);
         this.ctx.waitUntil(
           defaultDeviceId(this.env, pid).then((deviceId) =>

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -59,8 +59,9 @@ export type SeriesRow = {
   value: unknown;
 };
 
+// The artifact goes to R2 on its own route; only its id crosses the DO.
 export type BuildOutcome =
-  | { ok: true; binary: string; log: string[] }
+  | { ok: true; build: string; log: string[] }
   | { ok: false; error: string; log: string[] };
 
 export type FlushResult = {
@@ -501,9 +502,10 @@ export class ProjectDO extends DurableObject<Env> {
     }
     if (msg['type'] !== 'result') return;
     this.pendingBuilds.delete(build);
+    // The agent uploads before it reports, so ok means the object is already there.
     pending.resolve(
-      msg['ok'] === true && typeof msg['binary'] === 'string'
-        ? { ok: true, binary: msg['binary'], log: pending.log }
+      msg['ok'] === true
+        ? { ok: true, build, log: pending.log }
         : { ok: false, error: String(msg['error'] ?? 'build failed'), log: pending.log }
     );
   }
@@ -662,7 +664,7 @@ export class ProjectDO extends DurableObject<Env> {
     const projectId = this.projectId();
 
     // A prefix added elsewhere and not listed here leaks objects nothing reaches.
-    for (const prefix of [`telemetry/${projectId}/`, `firmware/${projectId}/`]) {
+    for (const prefix of [`telemetry/${projectId}/`, `firmware/${projectId}/`, `builds/${projectId}/`]) {
       let cursor: string | undefined;
       do {
         const list = await this.env.R2.list({ prefix, ...(cursor ? { cursor } : {}) });

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -18,8 +18,8 @@ import { migrateSchema, type SchemaStep } from './schema';
 
 const RING_BUFFER_MAX_ROWS = 1000;
 const RING_BUFFER_MAX_AGE_SECONDS = 60 * 60; // 1 hour
-// Multi-row inserts bind 3 columns/row; this keeps a chunk under MAX_BOUND_PARAMS.
-const ROWS_PER_3COL_INSERT = Math.floor(MAX_BOUND_PARAMS / 3);
+// Multi-row inserts bind 4 columns/row; this keeps a chunk under MAX_BOUND_PARAMS.
+const ROWS_PER_4COL_INSERT = Math.floor(MAX_BOUND_PARAMS / 4);
 // Eviction (age + overflow DELETE + COUNT) runs at most this often instead of on
 // every ingest — a single cheap last_evict_at lookup gates the actual work.
 const EVICT_INTERVAL_SECONDS = 30;
@@ -40,6 +40,7 @@ export type IngestResult = {
 };
 
 export type LatestStateRow = {
+  device_id: string;
   variable: string;
   value: unknown;
   received_at: number;
@@ -105,6 +106,32 @@ const SCHEMA: SchemaStep[] = [
       );
     `);
   },
+  // '' is the default device. NULL can't serve: SQLite treats NULLs as distinct
+  // in a unique key, so the upsert would duplicate on every write.
+  (sql) => {
+    sql.exec(`
+      CREATE TABLE latest_state_new (
+        device_id   TEXT NOT NULL DEFAULT '',
+        variable    TEXT NOT NULL,
+        value       TEXT NOT NULL,
+        received_at INTEGER NOT NULL,
+        PRIMARY KEY (device_id, variable)
+      );
+    `);
+    sql.exec(`
+      INSERT INTO latest_state_new (device_id, variable, value, received_at)
+      SELECT '', variable, value, received_at FROM latest_state;
+    `);
+    sql.exec(`DROP TABLE latest_state;`);
+    sql.exec(`ALTER TABLE latest_state_new RENAME TO latest_state;`);
+
+    sql.exec(`ALTER TABLE ring_buffer ADD COLUMN device_id TEXT NOT NULL DEFAULT '';`);
+    sql.exec(`DROP INDEX IF EXISTS idx_ring_buffer_var_ts;`);
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_dev_var_ts ON ring_buffer(device_id, variable, ts);`);
+
+    // NULL device still broadcasts.
+    sql.exec(`ALTER TABLE pending_control ADD COLUMN device_id TEXT;`);
+  },
 ];
 
 export class ProjectDO extends DurableObject<Env> {
@@ -132,7 +159,7 @@ export class ProjectDO extends DurableObject<Env> {
     );
   }
 
-  async ingest(projectId: string, points: IngestPoint[], _deviceTs?: number): Promise<IngestResult> {
+  async ingest(projectId: string, points: IngestPoint[], deviceId = ''): Promise<IngestResult> {
     const receivedAt = Math.floor(Date.now() / 1000);
 
     // Persist project_id once for the R2 key (idFromName doesn't round-trip cheaply).
@@ -152,7 +179,8 @@ export class ProjectDO extends DurableObject<Env> {
       const placeholders = part.map(() => '?').join(',');
       const rows = this.sql
         .exec<{ variable: string; value: string }>(
-          `SELECT variable, value FROM latest_state WHERE variable IN (${placeholders})`,
+          `SELECT variable, value FROM latest_state WHERE device_id = ? AND variable IN (${placeholders})`,
+          deviceId,
           ...part
         )
         .toArray();
@@ -163,28 +191,28 @@ export class ProjectDO extends DurableObject<Env> {
     // can't have two VALUES rows hit the same conflict target).
     const latestByVar = new Map<string, unknown>();
     for (const p of points) latestByVar.set(p.variable, p.value);
-    for (const part of chunk([...latestByVar], ROWS_PER_3COL_INSERT)) {
-      const rows = part.map(() => '(?, ?, ?)').join(', ');
+    for (const part of chunk([...latestByVar], ROWS_PER_4COL_INSERT)) {
+      const rows = part.map(() => '(?, ?, ?, ?)').join(', ');
       const binds: unknown[] = [];
       for (const [variable, value] of part) {
-        binds.push(variable, JSON.stringify(value), receivedAt);
+        binds.push(deviceId, variable, JSON.stringify(value), receivedAt);
       }
       this.sql.exec(
-        `INSERT INTO latest_state (variable, value, received_at)
+        `INSERT INTO latest_state (device_id, variable, value, received_at)
          VALUES ${rows}
-         ON CONFLICT(variable) DO UPDATE SET value = excluded.value, received_at = excluded.received_at`,
+         ON CONFLICT(device_id, variable) DO UPDATE SET value = excluded.value, received_at = excluded.received_at`,
         ...binds
       );
     }
 
     // ring_buffer: append every point.
-    for (const part of chunk(points, ROWS_PER_3COL_INSERT)) {
-      const rows = part.map(() => '(?, ?, ?)').join(', ');
+    for (const part of chunk(points, ROWS_PER_4COL_INSERT)) {
+      const rows = part.map(() => '(?, ?, ?, ?)').join(', ');
       const binds: unknown[] = [];
       for (const p of part) {
-        binds.push(receivedAt, p.variable, JSON.stringify(p.value));
+        binds.push(receivedAt, deviceId, p.variable, JSON.stringify(p.value));
       }
-      this.sql.exec(`INSERT INTO ring_buffer (ts, variable, value) VALUES ${rows}`, ...binds);
+      this.sql.exec(`INSERT INTO ring_buffer (ts, device_id, variable, value) VALUES ${rows}`, ...binds);
     }
 
     // Eviction is independent of the flush cursor (copy-not-move).
@@ -338,11 +366,13 @@ export class ProjectDO extends DurableObject<Env> {
 
   async getLatestState(): Promise<LatestStateRow[]> {
     const rows = this.sql
-      .exec<{ variable: string; value: string; received_at: number }>(
-        `SELECT variable, value, received_at FROM latest_state ORDER BY variable ASC`
+      .exec<{ device_id: string; variable: string; value: string; received_at: number }>(
+        `SELECT device_id, variable, value, received_at FROM latest_state
+         ORDER BY device_id ASC, variable ASC`
       )
       .toArray();
     return rows.map((r) => ({
+      device_id: r.device_id,
       variable: r.variable,
       value: safeParse(r.value),
       received_at: r.received_at,
@@ -354,18 +384,21 @@ export class ProjectDO extends DurableObject<Env> {
   async getSeriesForVariables(
     variables: string[],
     sinceTs: number | null,
-    cap?: number
+    cap?: number,
+    deviceId?: string | null
   ): Promise<CompactSeries> {
     if (variables.length === 0) return {};
     const cutoff = sinceTs ?? 0;
     const placeholders = variables.map(() => '?').join(',');
+    const scoped = deviceId != null;
     const rows = this.sql
       .exec<{ ts: number; variable: string; value: string }>(
         `SELECT ts, variable, value FROM ring_buffer
-         WHERE variable IN (${placeholders}) AND ts >= ?
+         WHERE variable IN (${placeholders}) AND ts >= ?${scoped ? ' AND device_id = ?' : ''}
          ORDER BY ts ASC`,
         ...variables,
-        cutoff
+        cutoff,
+        ...(scoped ? [deviceId] : [])
       )
       .toArray();
     return toCompactSeries(
@@ -374,26 +407,24 @@ export class ProjectDO extends DurableObject<Env> {
     );
   }
 
-  async getSeries(variable: string | null, sinceTs: number | null): Promise<SeriesRow[]> {
+  async getSeries(
+    variable: string | null,
+    sinceTs: number | null,
+    deviceId?: string | null
+  ): Promise<SeriesRow[]> {
     const cutoff = sinceTs ?? 0;
-    const rows = variable
-      ? this.sql
-          .exec<{ ts: number; variable: string; value: string }>(
-            `SELECT ts, variable, value FROM ring_buffer
-             WHERE variable = ? AND ts >= ?
-             ORDER BY ts ASC`,
-            variable,
-            cutoff
-          )
-          .toArray()
-      : this.sql
-          .exec<{ ts: number; variable: string; value: string }>(
-            `SELECT ts, variable, value FROM ring_buffer
-             WHERE ts >= ?
-             ORDER BY ts ASC`,
-            cutoff
-          )
-          .toArray();
+    const where = ['ts >= ?'];
+    const binds: unknown[] = [cutoff];
+    if (variable) { where.push('variable = ?'); binds.push(variable); }
+    if (deviceId != null) { where.push('device_id = ?'); binds.push(deviceId); }
+    const rows = this.sql
+      .exec<{ ts: number; variable: string; value: string }>(
+        `SELECT ts, variable, value FROM ring_buffer
+         WHERE ${where.join(' AND ')}
+         ORDER BY ts ASC`,
+        ...binds
+      )
+      .toArray();
     return rows.map((r) => ({ ts: r.ts, variable: r.variable, value: safeParse(r.value) }));
   }
 
@@ -456,10 +487,16 @@ export class ProjectDO extends DurableObject<Env> {
 
   // Drops hot state for a variable. Cold R2 history (partitioned by project+hour)
   // is left in place — orphaned but harmless.
-  async deleteVariable(variable: string): Promise<void> {
-    this.sql.exec(`DELETE FROM latest_state WHERE variable = ?`, variable);
-    this.sql.exec(`DELETE FROM ring_buffer WHERE variable = ?`, variable);
-    this.sql.exec(`DELETE FROM pending_control WHERE variable = ?`, variable);
+  async deleteVariable(variable: string, deviceId?: string | null): Promise<void> {
+    if (deviceId == null) {
+      this.sql.exec(`DELETE FROM latest_state WHERE variable = ?`, variable);
+      this.sql.exec(`DELETE FROM ring_buffer WHERE variable = ?`, variable);
+      this.sql.exec(`DELETE FROM pending_control WHERE variable = ?`, variable);
+      return;
+    }
+    this.sql.exec(`DELETE FROM latest_state WHERE variable = ? AND device_id = ?`, variable, deviceId);
+    this.sql.exec(`DELETE FROM ring_buffer WHERE variable = ? AND device_id = ?`, variable, deviceId);
+    this.sql.exec(`DELETE FROM pending_control WHERE variable = ? AND device_id IS ?`, variable, deviceId);
   }
 
   async flushNow(): Promise<FlushResult> {
@@ -614,8 +651,8 @@ export class ProjectDO extends DurableObject<Env> {
   private async runFlush(): Promise<FlushResult> {
     const cursor = this.getFlushCursor();
     const rows = this.sql
-      .exec<{ rowid: number; ts: number; variable: string; value: string }>(
-        `SELECT rowid, ts, variable, value FROM ring_buffer WHERE rowid > ? ORDER BY rowid ASC`,
+      .exec<{ rowid: number; ts: number; device_id: string; variable: string; value: string }>(
+        `SELECT rowid, ts, device_id, variable, value FROM ring_buffer WHERE rowid > ? ORDER BY rowid ASC`,
         cursor
       )
       .toArray();
@@ -639,7 +676,7 @@ export class ProjectDO extends DurableObject<Env> {
       const key = `telemetry/${projectId}/${bucket}/r-${lastRowid.toString().padStart(12, '0')}.ndjson`;
       const body = bucketRows
         .map((r) =>
-          JSON.stringify({ ts: r.ts, variable: r.variable, value: safeParse(r.value) })
+          JSON.stringify({ ts: r.ts, device: r.device_id || null, variable: r.variable, value: safeParse(r.value) })
         )
         .join('\n') + '\n';
 

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -11,6 +11,7 @@ import { chunk, MAX_BOUND_PARAMS } from '../lib/sql';
 import { parseDeviceMessage } from '../../domains/telemetry/ws-protocol';
 import { upsertVariables } from '../../domains/telemetry/variables';
 import { defaultDeviceId, normaliseDeviceKey, resolveDevice, recordDeviceSeen } from '../../domains/devices/service';
+import { reconcile } from '../../domains/firmware/ota';
 import { migrateSchema, type SchemaStep } from './schema';
 
 // Project Durable Object (one per project id, SQLite-backed): latest variable
@@ -536,6 +537,15 @@ export class ProjectDO extends DurableObject<Env> {
     }
   }
 
+  // A nudge, not a push: the device still decides whether to pull.
+  async notifyOta(deviceId: string): Promise<void> {
+    const payload = JSON.stringify({ type: 'ota' });
+    for (const ws of this.ctx.getWebSockets()) {
+      if (this.deviceOf(ws) !== deviceId) continue;
+      try { ws.send(payload); } catch { /* dead socket; ignore */ }
+    }
+  }
+
   async deleteDevice(deviceId: string): Promise<void> {
     this.sql.exec(`DELETE FROM latest_state WHERE device_id = ?`, deviceId);
     this.sql.exec(`DELETE FROM ring_buffer WHERE device_id = ?`, deviceId);
@@ -578,7 +588,10 @@ export class ProjectDO extends DurableObject<Env> {
         const device = key ? await resolveDevice(this.env, pid, key, Math.floor(Date.now() / 1000)) : null;
         if (!device || !device.storageId) return;
         ws.serializeAttachment({ device: device.storageId });
-        this.ctx.waitUntil(recordDeviceSeen(this.env, device.id, msg.chip, msg.firmware));
+        this.ctx.waitUntil(
+          recordDeviceSeen(this.env, device.id, msg.chip, msg.firmware)
+            .then(() => reconcile(this.env, device.id, msg.firmware ?? null))
+        );
         this.sendPending(ws, `device_id = ?`, device.storageId);
         return;
       }

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -221,7 +221,7 @@ export class ProjectDO extends DurableObject<Env> {
 
     // Fire-and-forget; failures never block ingest — the device already got its 204.
     this.notifyDashboards(points, receivedAt);
-    this.evaluateVariableTriggers(projectId, points, prev, receivedAt);
+    this.evaluateVariableTriggers(projectId, points, prev, receivedAt, deviceId);
 
     return { receivedAt, count: points.length };
   }
@@ -230,7 +230,8 @@ export class ProjectDO extends DurableObject<Env> {
     projectId: string,
     points: IngestPoint[],
     prev: Map<string, unknown>,
-    ts: number
+    ts: number,
+    deviceId: string
   ): void {
     this.ctx.waitUntil(
       (async () => {
@@ -238,16 +239,23 @@ export class ProjectDO extends DurableObject<Env> {
           const autos = await this.getVariableAutomations(projectId);
           if (autos.length === 0) return;
 
+          // Triggers name devices by their D1 id; storage calls the default one ''.
+          const triggerDevice = deviceId || (await defaultDeviceId(this.env, projectId)) || '';
+
+          // Both stay on the device that triggered: an automation that reacts to one
+          // greenhouse shouldn't read or switch another's.
           const setVariable = (variable: string, value: unknown): Promise<void> =>
-            this.addControl(newId('control'), variable, value);
-          // Condition nodes read live values; serve them from this DO's own state.
+            this.addControl(newId('control'), variable, value, deviceId);
           const getVariable = async (variable: string): Promise<unknown> =>
-            (await this.getLatestState()).find((r) => r.variable === variable)?.value;
+            (await this.getLatestState())
+              .find((r) => r.device_id === deviceId && r.variable === variable)?.value;
 
           for (const a of autos) {
             for (const node of triggerNodes(toGraph(a))) {
               if (node.kind !== 'variable') continue;
               const cfg = node.config as VariableTriggerConfig;
+
+              if (cfg.device && cfg.device !== triggerDevice) continue;
 
               const point = points.find((p) => p.variable === cfg.variable);
               if (!point) continue;
@@ -259,6 +267,7 @@ export class ProjectDO extends DurableObject<Env> {
                 ts,
                 variable: cfg.variable,
                 value: point.value,
+                device: triggerDevice,
                 depth: 0,
                 entryNodeId: node.id,
               };
@@ -463,26 +472,30 @@ export class ProjectDO extends DurableObject<Env> {
     this.notifyDashboards([{ variable, value: value as IngestPoint['value'] }], now);
   }
 
-  async listPendingControl(): Promise<Array<{ id: string; variable: string; value: unknown }>> {
+  // A device sees broadcasts and its own writes, never another device's.
+  async listPendingControl(deviceId = ''): Promise<Array<{ id: string; variable: string; value: unknown }>> {
     const rows = this.sql
       .exec<{ id: string; variable: string; value: string }>(
         `SELECT id, variable, value FROM pending_control
-         WHERE delivered_at IS NULL
-         ORDER BY created_at ASC`
+         WHERE delivered_at IS NULL AND (device_id IS NULL OR device_id = ?)
+         ORDER BY created_at ASC`,
+        deviceId
       )
       .toArray();
     return rows.map((r) => ({ id: r.id, variable: r.variable, value: safeParse(r.value) }));
   }
 
-  async ackControl(ids: string[]): Promise<{ acked: number }> {
+  async ackControl(ids: string[], deviceId = ''): Promise<{ acked: number }> {
     if (ids.length === 0) return { acked: 0 };
     const now = Math.floor(Date.now() / 1000);
     const placeholders = ids.map(() => '?').join(',');
     const cursor = this.sql.exec(
       `UPDATE pending_control SET delivered_at = ?
-        WHERE id IN (${placeholders}) AND delivered_at IS NULL`,
+        WHERE id IN (${placeholders}) AND delivered_at IS NULL
+          AND (device_id IS NULL OR device_id = ?)`,
       now,
-      ...ids
+      ...ids,
+      deviceId
     );
     return { acked: cursor.rowsWritten };
   }
@@ -570,7 +583,7 @@ export class ProjectDO extends DurableObject<Env> {
         return;
       }
       case 'ack':
-        if (msg.ids.length > 0) await this.ackControl(msg.ids);
+        if (msg.ids.length > 0) await this.ackControl(msg.ids, this.deviceOf(ws));
         return;
       case 'telemetry': {
         const pid = this.projectId();

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -18,7 +18,8 @@ import { PROJECT_SCHEMA } from './project-schema';
 // Project Durable Object (one per project id, SQLite-backed): latest variable
 // state, recent ring buffer, pending control writes, and the R2 flush cursor.
 
-const RING_BUFFER_MAX_ROWS = 1000;
+// Shared across devices this would silently thin every chart as hardware is added.
+const RING_BUFFER_MAX_ROWS_PER_DEVICE = 1000;
 const RING_BUFFER_MAX_AGE_SECONDS = 60 * 60; // 1 hour
 // Multi-row inserts bind 4 columns/row; this keeps a chunk under MAX_BOUND_PARAMS.
 const ROWS_PER_4COL_INSERT = Math.floor(MAX_BOUND_PARAMS / 4);
@@ -699,16 +700,20 @@ export class ProjectDO extends DurableObject<Env> {
     const ageCutoff = now - RING_BUFFER_MAX_AGE_SECONDS;
     this.sql.exec(`DELETE FROM ring_buffer WHERE ts < ?`, ageCutoff);
 
-    const row = this.sql
-      .exec<{ count: number }>(`SELECT COUNT(*) AS count FROM ring_buffer`)
-      .one();
-    if (row.count > RING_BUFFER_MAX_ROWS) {
-      const overflow = row.count - RING_BUFFER_MAX_ROWS;
+    const over = this.sql
+      .exec<{ device_id: string; count: number }>(
+        `SELECT device_id, COUNT(*) AS count FROM ring_buffer
+          GROUP BY device_id HAVING count > ?`,
+        RING_BUFFER_MAX_ROWS_PER_DEVICE
+      )
+      .toArray();
+    for (const d of over) {
       this.sql.exec(
         `DELETE FROM ring_buffer WHERE rowid IN (
-           SELECT rowid FROM ring_buffer ORDER BY rowid ASC LIMIT ?
+           SELECT rowid FROM ring_buffer WHERE device_id = ? ORDER BY rowid ASC LIMIT ?
          )`,
-        overflow
+        d.device_id,
+        d.count - RING_BUFFER_MAX_ROWS_PER_DEVICE
       );
     }
 

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -499,6 +499,12 @@ export class ProjectDO extends DurableObject<Env> {
     this.sql.exec(`DELETE FROM pending_control WHERE variable = ? AND device_id IS ?`, variable, deviceId);
   }
 
+  async deleteDevice(deviceId: string): Promise<void> {
+    this.sql.exec(`DELETE FROM latest_state WHERE device_id = ?`, deviceId);
+    this.sql.exec(`DELETE FROM ring_buffer WHERE device_id = ?`, deviceId);
+    this.sql.exec(`DELETE FROM pending_control WHERE device_id = ?`, deviceId);
+  }
+
   async flushNow(): Promise<FlushResult> {
     return this.runFlush();
   }

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -12,7 +12,8 @@ import { parseDeviceMessage } from '../../domains/telemetry/ws-protocol';
 import { upsertVariables } from '../../domains/telemetry/variables';
 import { defaultDeviceId, normaliseDeviceKey, resolveDevice, recordDeviceSeen } from '../../domains/devices/service';
 import { reconcile } from '../../domains/firmware/ota';
-import { migrateSchema, type SchemaStep } from './schema';
+import { migrateSchema } from './schema';
+import { PROJECT_SCHEMA } from './project-schema';
 
 // Project Durable Object (one per project id, SQLite-backed): latest variable
 // state, recent ring buffer, pending control writes, and the R2 flush cursor.
@@ -61,91 +62,6 @@ export type FlushResult = {
   newCursor: number;
 };
 
-const SCHEMA: SchemaStep[] = [
-  (sql) => {
-    sql.exec(`
-      CREATE TABLE IF NOT EXISTS latest_state (
-        variable    TEXT PRIMARY KEY,
-        value       TEXT NOT NULL,
-        received_at INTEGER NOT NULL
-      );
-    `);
-    sql.exec(`
-      CREATE TABLE IF NOT EXISTS ring_buffer (
-        rowid    INTEGER PRIMARY KEY AUTOINCREMENT,
-        ts       INTEGER NOT NULL,
-        variable TEXT NOT NULL,
-        value    TEXT NOT NULL
-      );
-    `);
-    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_ts ON ring_buffer(ts);`);
-    // Serves the per-variable series reads (chart snapshots + delta polls); the
-    // ts-only index above stays for age-based eviction.
-    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_var_ts ON ring_buffer(variable, ts);`);
-    sql.exec(`
-      CREATE TABLE IF NOT EXISTS pending_control (
-        id           TEXT PRIMARY KEY,
-        variable     TEXT NOT NULL,
-        value        TEXT NOT NULL,
-        created_at   INTEGER NOT NULL,
-        delivered_at INTEGER
-      );
-    `);
-    sql.exec(`
-      CREATE TABLE IF NOT EXISTS flush_meta (
-        k TEXT PRIMARY KEY,
-        v TEXT
-      );
-    `);
-    sql.exec(`
-      CREATE TABLE IF NOT EXISTS subscriptions (
-        dashboard_id TEXT PRIMARY KEY
-      );
-    `);
-    sql.exec(`
-      CREATE TABLE IF NOT EXISTS auto_cache (
-        k TEXT PRIMARY KEY,
-        v TEXT
-      );
-    `);
-  },
-  // '' is the default device. NULL can't serve: SQLite treats NULLs as distinct
-  // in a unique key, so the upsert would duplicate on every write.
-  (sql) => {
-    sql.exec(`
-      CREATE TABLE latest_state_new (
-        device_id   TEXT NOT NULL DEFAULT '',
-        variable    TEXT NOT NULL,
-        value       TEXT NOT NULL,
-        received_at INTEGER NOT NULL,
-        PRIMARY KEY (device_id, variable)
-      );
-    `);
-    sql.exec(`
-      INSERT INTO latest_state_new (device_id, variable, value, received_at)
-      SELECT '', variable, value, received_at FROM latest_state;
-    `);
-    sql.exec(`DROP TABLE latest_state;`);
-    sql.exec(`ALTER TABLE latest_state_new RENAME TO latest_state;`);
-
-    sql.exec(`ALTER TABLE ring_buffer ADD COLUMN device_id TEXT NOT NULL DEFAULT '';`);
-    sql.exec(`DROP INDEX IF EXISTS idx_ring_buffer_var_ts;`);
-    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_dev_var_ts ON ring_buffer(device_id, variable, ts);`);
-
-    // NULL device still broadcasts.
-    sql.exec(`ALTER TABLE pending_control ADD COLUMN device_id TEXT;`);
-  },
-  (sql) => {
-    sql.exec(`
-      CREATE TABLE IF NOT EXISTS ota_quota (
-        device_id TEXT NOT NULL,
-        window    INTEGER NOT NULL,
-        count     INTEGER NOT NULL,
-        PRIMARY KEY (device_id, window)
-      );
-    `);
-  },
-];
 
 export class ProjectDO extends DurableObject<Env> {
   private sql: SqlStorage;
@@ -160,7 +76,7 @@ export class ProjectDO extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
-    migrateSchema(ctx, SCHEMA);
+    migrateSchema(ctx, PROJECT_SCHEMA);
   }
 
   // WS connect calls this so the DO has its project_id for socket-driven ingest —

--- a/worker/src/platform/durable-objects/project-schema.ts
+++ b/worker/src/platform/durable-objects/project-schema.ts
@@ -1,0 +1,87 @@
+import type { SchemaStep } from './schema';
+
+export const PROJECT_SCHEMA: SchemaStep[] = [
+  (sql) => {
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS latest_state (
+        variable    TEXT PRIMARY KEY,
+        value       TEXT NOT NULL,
+        received_at INTEGER NOT NULL
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS ring_buffer (
+        rowid    INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts       INTEGER NOT NULL,
+        variable TEXT NOT NULL,
+        value    TEXT NOT NULL
+      );
+    `);
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_ts ON ring_buffer(ts);`);
+    // Serves the per-variable series reads (chart snapshots + delta polls); the
+    // ts-only index above stays for age-based eviction.
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_var_ts ON ring_buffer(variable, ts);`);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS pending_control (
+        id           TEXT PRIMARY KEY,
+        variable     TEXT NOT NULL,
+        value        TEXT NOT NULL,
+        created_at   INTEGER NOT NULL,
+        delivered_at INTEGER
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS flush_meta (
+        k TEXT PRIMARY KEY,
+        v TEXT
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS subscriptions (
+        dashboard_id TEXT PRIMARY KEY
+      );
+    `);
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS auto_cache (
+        k TEXT PRIMARY KEY,
+        v TEXT
+      );
+    `);
+  },
+  // '' is the default device. NULL can't serve: SQLite treats NULLs as distinct
+  // in a unique key, so the upsert would duplicate on every write.
+  (sql) => {
+    sql.exec(`
+      CREATE TABLE latest_state_new (
+        device_id   TEXT NOT NULL DEFAULT '',
+        variable    TEXT NOT NULL,
+        value       TEXT NOT NULL,
+        received_at INTEGER NOT NULL,
+        PRIMARY KEY (device_id, variable)
+      );
+    `);
+    sql.exec(`
+      INSERT INTO latest_state_new (device_id, variable, value, received_at)
+      SELECT '', variable, value, received_at FROM latest_state;
+    `);
+    sql.exec(`DROP TABLE latest_state;`);
+    sql.exec(`ALTER TABLE latest_state_new RENAME TO latest_state;`);
+
+    sql.exec(`ALTER TABLE ring_buffer ADD COLUMN device_id TEXT NOT NULL DEFAULT '';`);
+    sql.exec(`DROP INDEX IF EXISTS idx_ring_buffer_var_ts;`);
+    sql.exec(`CREATE INDEX IF NOT EXISTS idx_ring_buffer_dev_var_ts ON ring_buffer(device_id, variable, ts);`);
+
+    // NULL device still broadcasts.
+    sql.exec(`ALTER TABLE pending_control ADD COLUMN device_id TEXT;`);
+  },
+  (sql) => {
+    sql.exec(`
+      CREATE TABLE IF NOT EXISTS ota_quota (
+        device_id TEXT NOT NULL,
+        window    INTEGER NOT NULL,
+        count     INTEGER NOT NULL,
+        PRIMARY KEY (device_id, window)
+      );
+    `);
+  },
+];

--- a/worker/src/platform/durable-objects/schema.ts
+++ b/worker/src/platform/durable-objects/schema.ts
@@ -1,0 +1,15 @@
+export type SchemaStep = (sql: SqlStorage) => void;
+
+// Objects that predate versioning have the tables but no version row, so the
+// baseline must stay CREATE ... IF NOT EXISTS — they replay it as a no-op.
+export function migrateSchema(ctx: DurableObjectState, steps: SchemaStep[]): void {
+  ctx.storage.transactionSync(() => {
+    const sql = ctx.storage.sql;
+    sql.exec(`CREATE TABLE IF NOT EXISTS schema_version (v INTEGER PRIMARY KEY)`);
+    const from = sql.exec<{ v: number }>(`SELECT v FROM schema_version`).toArray()[0]?.v ?? 0;
+    if (from >= steps.length) return;
+    for (let i = from; i < steps.length; i++) steps[i]!(sql);
+    sql.exec(`DELETE FROM schema_version`);
+    sql.exec(`INSERT INTO schema_version (v) VALUES (?)`, steps.length);
+  });
+}

--- a/worker/src/platform/engine/run.ts
+++ b/worker/src/platform/engine/run.ts
@@ -205,9 +205,11 @@ function defaultEmitEvent(env: Env): ActionDeps['emitEvent'] {
   };
 }
 
+// Schedule, sunset and manual runs carry no device; without this the first by
+// sort order wins.
 function defaultGetVariable(env: Env, projectId: string): (variable: string) => Promise<unknown> {
   return async (variable) => {
-    const rows = await projectStub(env, projectId).getLatestState();
+    const rows = await projectStub(env, projectId).getLatestState('');
     return rows.find((r) => r.variable === variable)?.value;
   };
 }

--- a/worker/src/platform/engine/types.ts
+++ b/worker/src/platform/engine/types.ts
@@ -7,6 +7,7 @@ export type VariableOperator = '>' | '<' | '>=' | '<=' | '==' | '!=' | 'changed'
 
 export type VariableTriggerConfig = {
   variable: string;                    // variable key
+  device?: string | null;              // device id; absent/null = any device
   operator: VariableOperator;
   value?: number | string | boolean;   // omitted for 'changed'
   mode?: 'edge' | 'always';            // edge (default): fire once on entry
@@ -49,6 +50,7 @@ export type AutomationContext = {
   ts: number;                          // unix seconds
   variable?: string;
   value?: unknown;
+  device?: string;                     // storage id of the device that triggered
   event?: string;
   payload?: Record<string, unknown>;
   depth: number;                       // emit_event recursion depth

--- a/worker/src/platform/lib/audit.ts
+++ b/worker/src/platform/lib/audit.ts
@@ -21,6 +21,7 @@ export async function isAuditEnabled(env: Env): Promise<boolean> {
 export type AuditTargetType =
   | 'project'
   | 'variable'
+  | 'device'
   | 'project_token'
   | 'dashboard'
   | 'token'

--- a/worker/src/platform/lib/audit.ts
+++ b/worker/src/platform/lib/audit.ts
@@ -22,6 +22,7 @@ export type AuditTargetType =
   | 'project'
   | 'variable'
   | 'device'
+  | 'firmware'
   | 'project_token'
   | 'dashboard'
   | 'token'

--- a/worker/src/platform/lib/ids.ts
+++ b/worker/src/platform/lib/ids.ts
@@ -7,6 +7,7 @@ import { nanoid } from 'nanoid';
 // tok_xxx  token       ctl_xxx  control write
 // aut_xxx  automation  itg_xxx  integration
 // wid_xxx  widget instance (inside a dashboard layout)
+// dev_xxx  device
 // dly_xxx  delay continuation (pending automation resume)
 
 const PREFIXES = {
@@ -20,6 +21,7 @@ const PREFIXES = {
   integration: 'itg',
   widget: 'wid',
   delay: 'dly',
+  device: 'dev',
 } as const;
 
 export type IdKind = keyof typeof PREFIXES;

--- a/worker/src/platform/lib/ids.ts
+++ b/worker/src/platform/lib/ids.ts
@@ -7,7 +7,7 @@ import { nanoid } from 'nanoid';
 // tok_xxx  token       ctl_xxx  control write
 // aut_xxx  automation  itg_xxx  integration
 // wid_xxx  widget instance (inside a dashboard layout)
-// dev_xxx  device
+// dev_xxx  device      fwr_xxx  firmware image
 // dly_xxx  delay continuation (pending automation resume)
 
 const PREFIXES = {
@@ -22,6 +22,7 @@ const PREFIXES = {
   widget: 'wid',
   delay: 'dly',
   device: 'dev',
+  firmware: 'fwr',
 } as const;
 
 export type IdKind = keyof typeof PREFIXES;

--- a/worker/src/platform/lib/ids.ts
+++ b/worker/src/platform/lib/ids.ts
@@ -8,6 +8,7 @@ import { nanoid } from 'nanoid';
 // aut_xxx  automation  itg_xxx  integration
 // wid_xxx  widget instance (inside a dashboard layout)
 // dev_xxx  device      fwr_xxx  firmware image
+// bld_xxx  agent build
 // dly_xxx  delay continuation (pending automation resume)
 
 const PREFIXES = {
@@ -23,6 +24,7 @@ const PREFIXES = {
   delay: 'dly',
   device: 'dev',
   firmware: 'fwr',
+  build: 'bld',
 } as const;
 
 export type IdKind = keyof typeof PREFIXES;

--- a/worker/src/platform/lib/layout.ts
+++ b/worker/src/platform/lib/layout.ts
@@ -30,6 +30,9 @@ export type Layout = {
   mobile?: { items: MobilePlacement[] } | null;
   // Public-view auto-refresh cadence in seconds (server-clamped).
   refresh?: number;
+  // Which device this dashboard reads. Absent means the project's default,
+  // which is what every dashboard did before devices existed.
+  device?: string | null;
 };
 
 // Public-view refresh bounds: floor matches the /state edge-cache TTL (polling
@@ -90,6 +93,12 @@ export function validateLayout(input: unknown): { ok: true; value: Layout } | { 
     refresh = Math.min(Math.max(Math.round(r), REFRESH_MIN), REFRESH_MAX);
   }
 
+  const d = input['device'];
+  if (d !== undefined && d !== null && typeof d !== 'string') {
+    return { ok: false, reason: 'layout.device must be a string or null' };
+  }
+  const device = typeof d === 'string' && d.trim() ? d.trim() : null;
+
   return {
     ok: true,
     value: {
@@ -97,6 +106,7 @@ export function validateLayout(input: unknown): { ok: true; value: Layout } | { 
       items: items as WidgetInstance[],
       ...(mobile !== undefined ? { mobile } : {}),
       ...(refresh !== undefined ? { refresh } : {}),
+      ...(device !== null ? { device } : {}),
     },
   };
 }

--- a/worker/src/routes.ts
+++ b/worker/src/routes.ts
@@ -20,6 +20,8 @@ import projects from './domains/projects/routes';
 import variables from './domains/variables/routes';
 import devicesRouter from './domains/devices/routes';
 import firmware from './domains/firmware/routes';
+import firmwareAdmin from './domains/firmware/admin';
+import otaDevice from './domains/firmware/device';
 import { readList, readState, readSeries } from './domains/variables/read';
 import dashboards from './domains/dashboards/routes';
 import publicDashboards from './domains/dashboards/public';
@@ -71,6 +73,8 @@ export function registerRoutes(app: App): void {
   app.route('/v1/admin/projects/:proj/variables', variables);
   app.route('/v1/admin/projects/:proj/devices', devicesRouter);
   app.route('/v1/admin/firmware', firmware);
+  app.route('/v1/admin/projects/:proj/firmware', firmwareAdmin);
+  app.route('/v1/ota', otaDevice);
   app.route('/v1/admin/projects/:proj/dashboards', dashboards);
   app.route('/v1/admin/projects/:proj/automations', automations);
   app.route('/v1/admin/projects/:proj/integrations', integrations);

--- a/worker/src/routes.ts
+++ b/worker/src/routes.ts
@@ -21,7 +21,7 @@ import variables from './domains/variables/routes';
 import devicesRouter from './domains/devices/routes';
 import firmware from './domains/firmware/routes';
 import firmwareAdmin from './domains/firmware/admin';
-import build, { agentWsHandler } from './domains/firmware/agent';
+import build, { agentWsHandler, agentArtifactHandler } from './domains/firmware/agent';
 import otaDevice from './domains/firmware/device';
 import { readList, readState, readSeries } from './domains/variables/read';
 import dashboards from './domains/dashboards/routes';
@@ -78,6 +78,7 @@ export function registerRoutes(app: App): void {
   app.route('/v1/ota', otaDevice);
   app.route('/v1/admin/projects/:proj/build', build);
   app.get('/v1/agent/ws', agentWsHandler);
+  app.put('/v1/agent/artifact/:build', agentArtifactHandler);
   app.route('/v1/admin/projects/:proj/dashboards', dashboards);
   app.route('/v1/admin/projects/:proj/automations', automations);
   app.route('/v1/admin/projects/:proj/integrations', integrations);

--- a/worker/src/routes.ts
+++ b/worker/src/routes.ts
@@ -19,6 +19,7 @@ import publicInvite from './domains/identity/public-invite';
 import projects from './domains/projects/routes';
 import variables from './domains/variables/routes';
 import devicesRouter from './domains/devices/routes';
+import firmware from './domains/firmware/routes';
 import { readList, readState, readSeries } from './domains/variables/read';
 import dashboards from './domains/dashboards/routes';
 import publicDashboards from './domains/dashboards/public';
@@ -69,6 +70,7 @@ export function registerRoutes(app: App): void {
   app.route('/v1/admin/projects', projects);
   app.route('/v1/admin/projects/:proj/variables', variables);
   app.route('/v1/admin/projects/:proj/devices', devicesRouter);
+  app.route('/v1/admin/firmware', firmware);
   app.route('/v1/admin/projects/:proj/dashboards', dashboards);
   app.route('/v1/admin/projects/:proj/automations', automations);
   app.route('/v1/admin/projects/:proj/integrations', integrations);

--- a/worker/src/routes.ts
+++ b/worker/src/routes.ts
@@ -18,6 +18,7 @@ import publicInvite from './domains/identity/public-invite';
 // projects / variables / dashboards / automations / integrations
 import projects from './domains/projects/routes';
 import variables from './domains/variables/routes';
+import devicesRouter from './domains/devices/routes';
 import { readList, readState, readSeries } from './domains/variables/read';
 import dashboards from './domains/dashboards/routes';
 import publicDashboards from './domains/dashboards/public';
@@ -67,6 +68,7 @@ export function registerRoutes(app: App): void {
   app.route('/v1/admin/invites', invitesRouter);
   app.route('/v1/admin/projects', projects);
   app.route('/v1/admin/projects/:proj/variables', variables);
+  app.route('/v1/admin/projects/:proj/devices', devicesRouter);
   app.route('/v1/admin/projects/:proj/dashboards', dashboards);
   app.route('/v1/admin/projects/:proj/automations', automations);
   app.route('/v1/admin/projects/:proj/integrations', integrations);

--- a/worker/src/routes.ts
+++ b/worker/src/routes.ts
@@ -21,6 +21,7 @@ import variables from './domains/variables/routes';
 import devicesRouter from './domains/devices/routes';
 import firmware from './domains/firmware/routes';
 import firmwareAdmin from './domains/firmware/admin';
+import build, { agentWsHandler } from './domains/firmware/agent';
 import otaDevice from './domains/firmware/device';
 import { readList, readState, readSeries } from './domains/variables/read';
 import dashboards from './domains/dashboards/routes';
@@ -75,6 +76,8 @@ export function registerRoutes(app: App): void {
   app.route('/v1/admin/firmware', firmware);
   app.route('/v1/admin/projects/:proj/firmware', firmwareAdmin);
   app.route('/v1/ota', otaDevice);
+  app.route('/v1/admin/projects/:proj/build', build);
+  app.get('/v1/agent/ws', agentWsHandler);
   app.route('/v1/admin/projects/:proj/dashboards', dashboards);
   app.route('/v1/admin/projects/:proj/automations', automations);
   app.route('/v1/admin/projects/:proj/integrations', integrations);

--- a/worker/test/device-seen.test.ts
+++ b/worker/test/device-seen.test.ts
@@ -1,0 +1,51 @@
+// A throttle that never lets go is the same bug as no write at all.
+// Run with `bun test worker/test/device-seen.test.ts`.
+
+import { test, expect } from 'bun:test';
+import { touchDevice } from '../src/domains/devices/service';
+import type { Env } from '../src/env';
+
+function fakeEnv(fail = false) {
+  const writes: string[] = [];
+  const env = {
+    DB: {
+      prepare() {
+        return {
+          bind(..._args: unknown[]) {
+            return {
+              run() {
+                if (fail) throw new Error('d1 down');
+                writes.push('write');
+                return Promise.resolve();
+              },
+            };
+          },
+        };
+      },
+    },
+  } as unknown as Env;
+  return { env, writes };
+}
+
+test('writes once and then throttles the same device', async () => {
+  const { env, writes } = fakeEnv();
+  await touchDevice(env, 'dev_throttle_a');
+  await touchDevice(env, 'dev_throttle_a');
+  await touchDevice(env, 'dev_throttle_a');
+  expect(writes.length).toBe(1);
+});
+
+test('throttles per device, not globally', async () => {
+  const { env, writes } = fakeEnv();
+  await touchDevice(env, 'dev_throttle_b');
+  await touchDevice(env, 'dev_throttle_c');
+  expect(writes.length).toBe(2);
+});
+
+test('a failed write retries on the next call', async () => {
+  const failing = fakeEnv(true);
+  await touchDevice(failing.env, 'dev_throttle_d');
+  const ok = fakeEnv();
+  await touchDevice(ok.env, 'dev_throttle_d');
+  expect(ok.writes.length).toBe(1);
+});

--- a/worker/test/do-schema.test.ts
+++ b/worker/test/do-schema.test.ts
@@ -1,0 +1,75 @@
+// Durable Objects have no migration runner, so a project created today and one
+// created before devices existed reach their schema by different routes. The
+// classic divergence is silent — a column NOT NULL on one and nullable on the
+// other — so the two are compared directly.
+// Run with `bun test worker/test/do-schema.test.ts`.
+
+import { test, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { PROJECT_SCHEMA } from '../src/platform/durable-objects/project-schema';
+
+// SqlStorage.exec(sql, ...binds) over bun:sqlite, which is what the steps expect.
+function storage(db: Database) {
+  return { exec: (sql: string, ...binds: unknown[]) => db.run(sql, ...(binds as never[])) };
+}
+
+function applySteps(db: Database, from: number, to: number) {
+  const sql = storage(db) as never;
+  for (let i = from; i < to; i++) PROJECT_SCHEMA[i]!(sql);
+}
+
+function schemaOf(db: Database): string {
+  return db
+    .query<{ type: string; name: string; sql: string | null }, []>(
+      `SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name`
+    )
+    .all()
+    .map((r) => `${r.type} ${r.name}\n${r.sql ?? ''}`)
+    .join('\n---\n');
+}
+
+test('an object built step by step matches one built fresh', () => {
+  const stepped = new Database(':memory:');
+  for (let i = 0; i < PROJECT_SCHEMA.length; i++) applySteps(stepped, i, i + 1);
+
+  const fresh = new Database(':memory:');
+  applySteps(fresh, 0, PROJECT_SCHEMA.length);
+
+  expect(schemaOf(stepped)).toBe(schemaOf(fresh));
+});
+
+test('rows written before devices existed land on the default device', () => {
+  const db = new Database(':memory:');
+  applySteps(db, 0, 1);
+  db.run(`INSERT INTO latest_state (variable, value, received_at) VALUES ('temp', '21', 100)`);
+  db.run(`INSERT INTO ring_buffer (ts, variable, value) VALUES (100, 'temp', '21')`);
+  applySteps(db, 1, PROJECT_SCHEMA.length);
+
+  expect(db.query(`SELECT device_id, variable FROM latest_state`).all())
+    .toEqual([{ device_id: '', variable: 'temp' }]);
+  expect(db.query(`SELECT device_id FROM ring_buffer`).all()).toEqual([{ device_id: '' }]);
+});
+
+// The reason '' is the sentinel rather than NULL: SQLite treats NULLs as
+// distinct in a unique key, so the upsert would append instead of updating.
+test('the default device upserts rather than duplicating', () => {
+  const db = new Database(':memory:');
+  applySteps(db, 0, PROJECT_SCHEMA.length);
+  const write = (value: string) =>
+    db.run(
+      `INSERT INTO latest_state (device_id, variable, value, received_at) VALUES ('', 'temp', ?, 1)
+       ON CONFLICT(device_id, variable) DO UPDATE SET value = excluded.value`,
+      value
+    );
+  write('21');
+  write('22');
+  expect(db.query(`SELECT value FROM latest_state`).all()).toEqual([{ value: '22' }]);
+});
+
+test('two devices keep separate state for the same variable', () => {
+  const db = new Database(':memory:');
+  applySteps(db, 0, PROJECT_SCHEMA.length);
+  db.run(`INSERT INTO latest_state (device_id, variable, value, received_at) VALUES ('', 'temp', '21', 1)`);
+  db.run(`INSERT INTO latest_state (device_id, variable, value, received_at) VALUES ('dev_b', 'temp', '30', 1)`);
+  expect(db.query(`SELECT COUNT(*) AS n FROM latest_state WHERE variable = 'temp'`).get()).toEqual({ n: 2 });
+});

--- a/worker/test/firmware-url.test.ts
+++ b/worker/test/firmware-url.test.ts
@@ -1,0 +1,39 @@
+// The only thing standing between this proxy and an open one.
+// Run with `bun test worker/test/firmware-url.test.ts`.
+
+import { test, expect } from 'bun:test';
+import { binaryUrl } from '../src/domains/firmware/service';
+
+test('builds a release asset URL from valid parts', () => {
+  expect(binaryUrl('v1.2.0', 'LedControl-esp32.bin'))
+    .toBe('https://github.com/decoded-cipher/nodrix-sdk/releases/download/v1.2.0/LedControl-esp32.bin');
+});
+
+test('refuses anything that is not a .bin', () => {
+  expect(binaryUrl('v1', 'LedControl-esp32.exe')).toBeNull();
+  expect(binaryUrl('v1', 'LedControl-esp32')).toBeNull();
+});
+
+test('refuses path traversal', () => {
+  expect(binaryUrl('..', 'a.bin')).toBeNull();
+  expect(binaryUrl('v1..2', 'a.bin')).toBeNull();
+  expect(binaryUrl('v1', '..a.bin')).toBeNull();
+  expect(binaryUrl('v1/../..', 'a.bin')).toBeNull();
+});
+
+test('refuses a host of the caller choosing', () => {
+  expect(binaryUrl('https://evil.example', 'a.bin')).toBeNull();
+  expect(binaryUrl('v1', 'https://evil.example/a.bin')).toBeNull();
+  expect(binaryUrl('v1@evil.example', 'a.bin')).toBeNull();
+});
+
+test('refuses encoded and control characters', () => {
+  expect(binaryUrl('%2e%2e', 'a.bin')).toBeNull();
+  expect(binaryUrl('v1\nHost: evil', 'a.bin')).toBeNull();
+  expect(binaryUrl('v1', 'a b.bin')).toBeNull();
+});
+
+test('refuses oversized parts', () => {
+  expect(binaryUrl('v'.repeat(65), 'a.bin')).toBeNull();
+  expect(binaryUrl('v1', `${'a'.repeat(129)}.bin`)).toBeNull();
+});

--- a/worker/test/migrations.test.ts
+++ b/worker/test/migrations.test.ts
@@ -147,6 +147,39 @@ test('one firmware version per project', () => {
   expect(() => insert('fw_c', 'prj_alpha')).toThrow();
 });
 
+// Mirrors the retention query in firmware/ota.ts — what it spares is the point.
+test('retention spares recent images and anything a device needs', () => {
+  const db = new Database(':memory:');
+  apply(db, 1);
+  seed(db);
+  apply(db, MIGRATIONS.length);
+
+  const add = (id: string, version: string, at: number) =>
+    db.run(`INSERT INTO firmware (id, project_id, version, size, sha256, r2_key, created_at)
+            VALUES ('${id}', 'prj_alpha', '${version}', 1, 'a', 'k', ${at})`);
+  add('fw_old', '0.1.0', 1);
+  add('fw_running', '0.2.0', 2);
+  add('fw_desired', '0.3.0', 3);
+  add('fw_recent', '0.4.0', 4);
+
+  db.run(`UPDATE devices SET firmware_version = '0.2.0' WHERE id = 'dev_alpha'`);
+  db.run(`INSERT INTO devices (id, project_id, name, desired_firmware_id, created_at)
+          VALUES ('dev_two', 'prj_alpha', 'Shed', 'fw_desired', 1)`);
+
+  const stale = db
+    .query<{ id: string }, []>(
+      `SELECT id FROM firmware
+        WHERE project_id = 'prj_alpha'
+          AND id NOT IN (SELECT id FROM firmware WHERE project_id = 'prj_alpha' ORDER BY created_at DESC LIMIT 1)
+          AND id NOT IN (SELECT desired_firmware_id FROM devices
+                          WHERE project_id = 'prj_alpha' AND desired_firmware_id IS NOT NULL)
+          AND version NOT IN (SELECT firmware_version FROM devices
+                               WHERE project_id = 'prj_alpha' AND firmware_version IS NOT NULL)`
+    )
+    .all();
+  expect(stale).toEqual([{ id: 'fw_old' }]);
+});
+
 // The baseline is all CREATE ... IF NOT EXISTS, including the index whose columns
 // 0002 changes. Replaying it must not put the old shape back.
 test('replaying the baseline over a migrated database changes nothing', () => {

--- a/worker/test/migrations.test.ts
+++ b/worker/test/migrations.test.ts
@@ -1,0 +1,128 @@
+// A fresh install and an upgraded one have to arrive at the same schema, and the
+// upgrade has to keep its data. Runs the real bundled statements against SQLite.
+// Run with `bun test worker/test/migrations.test.ts`.
+
+import { test, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { MIGRATIONS } from '../src/platform/db/migrations.gen';
+
+function apply(db: Database, upTo: number) {
+  for (const m of MIGRATIONS.slice(0, upTo)) {
+    for (const stmt of m.statements) db.run(stmt);
+  }
+}
+
+// Ordered so two databases built by different routes compare directly.
+function schemaOf(db: Database): string {
+  const rows = db
+    .query<{ type: string; name: string; sql: string | null }, []>(
+      `SELECT type, name, sql FROM sqlite_master
+       WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name`
+    )
+    .all();
+  return rows.map((r) => `${r.type} ${r.name}\n${r.sql ?? ''}`).join('\n---\n');
+}
+
+function seed(db: Database) {
+  db.run(`INSERT INTO users (id, email, name, role, created_at, updated_at)
+          VALUES ('usr_1', 'a@b.c', 'A', 'owner', 1, 1)`);
+  db.run(`INSERT INTO projects (id, name, created_by, created_at, updated_at)
+          VALUES ('prj_alpha', 'Alpha', 'usr_1', 100, 100),
+                 ('prj_beta', 'Beta', 'usr_1', 200, 200)`);
+  db.run(`INSERT INTO project_variables (id, project_id, key, unit, created_at, updated_at, last_seen)
+          VALUES ('var_1', 'prj_alpha', 'temp', 'C', 100, 100, 500),
+                 ('var_2', 'prj_alpha', 'humidity', NULL, 100, 100, 600),
+                 ('var_3', 'prj_beta', 'temp', NULL, 200, 200, NULL)`);
+}
+
+test('fresh and upgraded instances reach an identical schema', () => {
+  const upgraded = new Database(':memory:');
+  apply(upgraded, 1);
+  seed(upgraded);
+  apply(upgraded, MIGRATIONS.length);
+
+  const fresh = new Database(':memory:');
+  apply(fresh, MIGRATIONS.length);
+
+  expect(schemaOf(upgraded)).toBe(schemaOf(fresh));
+});
+
+test('the upgrade runs clean against an instance with no rows', () => {
+  const db = new Database(':memory:');
+  apply(db, 1);
+  expect(() => apply(db, MIGRATIONS.length)).not.toThrow();
+  expect(db.query(`SELECT COUNT(*) AS n FROM devices`).get()).toEqual({ n: 0 });
+});
+
+test('every project gets exactly one default device', () => {
+  const db = new Database(':memory:');
+  apply(db, 1);
+  seed(db);
+  apply(db, MIGRATIONS.length);
+
+  const devices = db
+    .query<{ id: string; project_id: string; name: string; is_default: number }, []>(
+      `SELECT id, project_id, name, is_default FROM devices ORDER BY project_id`
+    )
+    .all();
+  expect(devices).toEqual([
+    { id: 'dev_alpha', project_id: 'prj_alpha', name: 'Default', is_default: 1 },
+    { id: 'dev_beta', project_id: 'prj_beta', name: 'Default', is_default: 1 },
+  ]);
+});
+
+test('a second default device cannot be inserted', () => {
+  const db = new Database(':memory:');
+  apply(db, 1);
+  seed(db);
+  apply(db, MIGRATIONS.length);
+  expect(() =>
+    db.run(`INSERT INTO devices (id, project_id, name, is_default, created_at)
+            VALUES ('dev_x', 'prj_alpha', 'Second', 1, 1)`)
+  ).toThrow();
+});
+
+test('existing variables survive and land on their default device', () => {
+  const db = new Database(':memory:');
+  apply(db, 1);
+  seed(db);
+  apply(db, MIGRATIONS.length);
+
+  const rows = db
+    .query<{ id: string; project_id: string; device_id: string; key: string; unit: string | null; last_seen: number | null }, []>(
+      `SELECT id, project_id, device_id, key, unit, last_seen FROM project_variables ORDER BY id`
+    )
+    .all();
+  expect(rows).toEqual([
+    { id: 'var_1', project_id: 'prj_alpha', device_id: 'dev_alpha', key: 'temp', unit: 'C', last_seen: 500 },
+    { id: 'var_2', project_id: 'prj_alpha', device_id: 'dev_alpha', key: 'humidity', unit: null, last_seen: 600 },
+    { id: 'var_3', project_id: 'prj_beta', device_id: 'dev_beta', key: 'temp', unit: null, last_seen: null },
+  ]);
+});
+
+test('the same key is now allowed once per device', () => {
+  const db = new Database(':memory:');
+  apply(db, 1);
+  seed(db);
+  apply(db, MIGRATIONS.length);
+
+  db.run(`INSERT INTO devices (id, project_id, name, created_at) VALUES ('dev_two', 'prj_alpha', 'Shed', 1)`);
+  expect(() =>
+    db.run(`INSERT INTO project_variables (id, project_id, device_id, key, created_at, updated_at)
+            VALUES ('var_4', 'prj_alpha', 'dev_two', 'temp', 1, 1)`)
+  ).not.toThrow();
+  expect(() =>
+    db.run(`INSERT INTO project_variables (id, project_id, device_id, key, created_at, updated_at)
+            VALUES ('var_5', 'prj_alpha', 'dev_alpha', 'temp', 1, 1)`)
+  ).toThrow();
+});
+
+// The baseline is all CREATE ... IF NOT EXISTS, including the index whose columns
+// 0002 changes. Replaying it must not put the old shape back.
+test('replaying the baseline over a migrated database changes nothing', () => {
+  const db = new Database(':memory:');
+  apply(db, MIGRATIONS.length);
+  const before = schemaOf(db);
+  apply(db, 1);
+  expect(schemaOf(db)).toBe(before);
+});

--- a/worker/test/migrations.test.ts
+++ b/worker/test/migrations.test.ts
@@ -117,6 +117,36 @@ test('the same key is now allowed once per device', () => {
   ).toThrow();
 });
 
+test('a device points at desired firmware and survives its deletion', () => {
+  const db = new Database(':memory:');
+  db.run('PRAGMA foreign_keys = ON');
+  apply(db, 1);
+  seed(db);
+  apply(db, MIGRATIONS.length);
+
+  db.run(`INSERT INTO firmware (id, project_id, version, size, sha256, r2_key, created_at)
+          VALUES ('fw_1', 'prj_alpha', '1.4.0', 100, 'abc', 'k', 1)`);
+  db.run(`UPDATE devices SET desired_firmware_id = 'fw_1' WHERE id = 'dev_alpha'`);
+  db.run(`DELETE FROM firmware WHERE id = 'fw_1'`);
+
+  // ON DELETE SET NULL, so the device stays; it just has nothing pending.
+  const row = db.query(`SELECT desired_firmware_id FROM devices WHERE id = 'dev_alpha'`).get();
+  expect(row).toEqual({ desired_firmware_id: null });
+});
+
+test('one firmware version per project', () => {
+  const db = new Database(':memory:');
+  apply(db, 1);
+  seed(db);
+  apply(db, MIGRATIONS.length);
+  const insert = (id: string, project: string) =>
+    db.run(`INSERT INTO firmware (id, project_id, version, size, sha256, r2_key, created_at)
+            VALUES ('${id}', '${project}', '1.0.0', 1, 'a', 'k', 1)`);
+  insert('fw_a', 'prj_alpha');
+  expect(() => insert('fw_b', 'prj_beta')).not.toThrow();
+  expect(() => insert('fw_c', 'prj_alpha')).toThrow();
+});
+
 // The baseline is all CREATE ... IF NOT EXISTS, including the index whose columns
 // 0002 changes. Replaying it must not put the old shape back.
 test('replaying the baseline over a migrated database changes nothing', () => {

--- a/worker/test/ota-offer.test.ts
+++ b/worker/test/ota-offer.test.ts
@@ -1,0 +1,40 @@
+// Offering an update the board already applied is a reboot loop, not a retry.
+// Run with `bun test worker/test/ota-offer.test.ts`.
+
+import { test, expect } from 'bun:test';
+import { offerFor } from '../src/domains/firmware/ota';
+import type { Env } from '../src/env';
+
+function envWith(row: Record<string, unknown> | null) {
+  return {
+    DB: {
+      prepare: () => ({ bind: () => ({ first: () => Promise.resolve(row) }) }),
+    },
+  } as unknown as Env;
+}
+
+const desired = { version: '1.2.0', size: 100, sha256: 'abc', current: null };
+
+test('offers when the board runs something else', async () => {
+  const offer = await offerFor(envWith({ ...desired, current: '1.1.0' }), 'prj_a', 'dev_a');
+  expect(offer?.version).toBe('1.2.0');
+});
+
+test('offers nothing once the stored version matches', async () => {
+  const offer = await offerFor(envWith({ ...desired, current: '1.2.0' }), 'prj_a', 'dev_a');
+  expect(offer).toBeNull();
+});
+
+test('a version reported in the request beats the stored one', async () => {
+  const env = envWith({ ...desired, current: '1.1.0' });
+  expect(await offerFor(env, 'prj_a', 'dev_a', '1.2.0')).toBeNull();
+});
+
+test('a stale stored version does not suppress a real update', async () => {
+  const env = envWith({ ...desired, current: '1.2.0' });
+  expect((await offerFor(env, 'prj_a', 'dev_a', '1.1.0'))?.version).toBe('1.2.0');
+});
+
+test('offers nothing with no desired firmware', async () => {
+  expect(await offerFor(envWith(null), 'prj_a', 'dev_a')).toBeNull();
+});

--- a/worker/test/ws-protocol.test.ts
+++ b/worker/test/ws-protocol.test.ts
@@ -71,7 +71,24 @@ test('event with no name is an error frame', () => {
 });
 
 test('unknown type is ignored', () => {
+  expect(parseDeviceMessage(JSON.stringify({ type: 'wat' }))).toEqual({ kind: 'ignore' });
+});
+
+test('hello carries the device and its optional metadata', () => {
+  expect(parseDeviceMessage(JSON.stringify({ type: 'hello', device: 'a4:cf:12:00' })))
+    .toEqual({ kind: 'hello', device: 'a4:cf:12:00' });
+  expect(parseDeviceMessage(JSON.stringify({ type: 'hello', device: 'b1', chip: 'esp32s3', firmware: '1.4.0' })))
+    .toEqual({ kind: 'hello', device: 'b1', chip: 'esp32s3', firmware: '1.4.0' });
+});
+
+test('hello without a device is ignored', () => {
   expect(parseDeviceMessage(JSON.stringify({ type: 'hello' }))).toEqual({ kind: 'ignore' });
+  expect(parseDeviceMessage(JSON.stringify({ type: 'hello', device: '  ' }))).toEqual({ kind: 'ignore' });
+});
+
+test('hello metadata is length-capped', () => {
+  const m = parseDeviceMessage(JSON.stringify({ type: 'hello', device: 'b1', chip: 'x'.repeat(80) }));
+  expect(m.kind === 'hello' && m.chip?.length).toBe(32);
 });
 
 test('non-JSON is ignored', () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,9 +9,9 @@ compatibility_flags = ["nodejs_compat"]
 # bindings change; they can't be symlinked (the subdir must be self-contained).
 #
 # Build pipeline. scripts/build-from-upstream.sh, when running under Workers
-# Builds (detected via WORKERS_CI_COMMIT_SHA), replaces the clone's working
-# tree with upstream source before invoking the build chain. The user's
-# wrangler.toml (resource IDs from the Deploy button) is preserved across it.
+# Builds (detected via WORKERS_CI_COMMIT_SHA), replaces the clone's working tree
+# with upstream source, then rebuilds its wrangler.toml from deploy/wrangler.toml
+# — bindings from upstream, resource IDs and Worker name from the deployment.
 #
 # Locally the same script falls through to the standard build chain, so
 # `bun run build` / `wrangler deploy --dry-run` still work for development.


### PR DESCRIPTION
Nodrix picked up at the first telemetry POST — the board was already built, flashed, on Wi-Fi and holding a token. This builds the other half.

Not a release. `package.json` stays at 1.0.1 and no tag is cut, so release-channel deployments keep resolving the last published release. Merging only moves the `edge` channel.

## What lands

**Devices.** Every project gets a default device; variables are scoped to one. Boards auto-register on first sight the way variables always have. Dashboards, automations, control delivery and the MCP tools all address a device rather than a bare key.

**Browser as the tool.** Serial console with plain-language diagnosis, Web Serial flashing via esptool-js, a CodeMirror sketch editor seeded from published SDK examples. Both heavy libraries are lazy chunks kept out of the PWA precache.

**Firmware and OTA.** A per-project firmware store in R2 with retention, and updates by desired-state reconciliation — the device pulls, nothing orchestrates. Downloads are quota'd per device per hour and R2 bodies stream untouched, since free-tier CPU is 10ms.

**Builds.** `nodrix-agent` compiles on your own machine with your own `arduino-cli`. The DO brokers job control only; the artifact goes to R2 on a plain worker route.

## Data safety

The one hard constraint was that structures and APIs may break but data may not.

- D1 migrations apply one `db.batch()` each, which D1 rolls back as a transaction. `exec()`, which the docs suggest, stops on error without rolling back.
- Durable Objects have no migration runner, so each class now carries an ordered schema ladder walked forward inside `transactionSync`.
- A convergence test builds one database fresh and another by seeding 1.x data and migrating, then asserts `sqlite_master` matches. Same for DO storage.
- Project export as NDJSON, shipped first — it is the only floor under a one-shot migration running unattended on instances nobody can observe.

## Known gaps

Tracked, not blocking merge, and all of them are why this isn't a release:

- Browser builds flash app-only at `0x10000`; no merged image and no route from a build to OTA.
- Build logs reach the browser only when the build finishes, not while it runs.
- Sketches live in localStorage, not D1 — no pinned versions, no build snapshot.
- No missing-library flow.
- The agent's protocol version is sent and ignored, and it authenticates with an ordinary admin token rather than a pairing token.
- Build trigger isn't audited, though firmware upload, assign, delete and device rename/forget are.

Telemetry ingest and control-poll throttling remain deferred pending measurement. Nothing here has touched real hardware, a real D1, or a real board.
