### PR TITLE
Tell people what an agent is when a build needs one

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 🧠 **Native MCP server** — an owner-gated Model Context Protocol endpoint with a Claude connector for AI clients (off by default).
 - 👥 **Multi-user** — owner / admin / member roles, email invites, and social sign-in (Google, GitHub).
 - 📝 **Audit log** — every privileged action recorded and paginated in the UI.
+- 🔧 **Write, build and flash from the browser** — a code editor, serial monitor and Web Serial flasher in one page; the [nodrix agent](https://github.com/decoded-cipher/nodrix-agent) compiles on your machine, and the same build ships over the air.
 
 ## Quick start
 
@@ -36,12 +37,30 @@
      -H "Authorization: Bearer $NODRIX_TOKEN"
    ```
 
+## Flashing hardware from the browser
+
+The Code page pairs an editor with a serial monitor and flashes over Web Serial, so a board goes from sketch to running without leaving the browser. Compiling is the one part a browser cannot do — the ESP32 sysroot alone is over 150 MB — so it runs on your own machine via the agent.
+
+```bash
+curl -fsSL -o nodrix-agent \
+  https://github.com/decoded-cipher/nodrix-agent/releases/latest/download/nodrix-agent-macos-arm64
+chmod +x nodrix-agent
+arduino-cli core install esp32:esp32
+
+NODRIX_INSTANCE=https://<your-worker> NODRIX_TOKEN=<admin token> ./nodrix-agent
+```
+
+Other platforms are on the [agent releases](https://github.com/decoded-cipher/nodrix-agent/releases/latest). The agent dials out to your instance, so there is no port to open and no certificate to install; it never touches the serial port, which the browser owns. Flashing needs Chrome, Edge or Opera on desktop, or Chrome on Android — Safari and Firefox have no Web Serial.
+
+Keep a build and it becomes a firmware version you can send to any device over the air.
+
 ## Architecture
 
 - **Worker** ([worker/](worker/)) — a single Hono app. Durable Objects for Project, Dashboard, Scheduler, and the MCP agent; one Workflow for provisioning; D1 (metadata), R2 (telemetry history), KV (read cache + JWKS).
 - **Web** ([web/](web/)) — Vue 3 + Tailwind + Reka UI admin panel and drag-and-drop dashboard builder, built and served as Worker static assets.
 - **Shared** ([shared/](shared/)) — framework-agnostic Web Component widgets, the integration catalog, and automation blocks, consumed by both web and worker so there is a single source of truth.
 - **Deploy** ([deploy/](deploy/)) — the small config carrier behind the one-click Deploy to Cloudflare.
+- **Agent** ([nodrix-agent](https://github.com/decoded-cipher/nodrix-agent)) — an optional CLI on your own machine that runs `arduino-cli` for browser builds. Separate repo, separate release.
 
 ```
 worker/   Cloudflare Worker — API, Durable Objects, Workflow

--- a/web/src/composables/useAgentBuild.ts
+++ b/web/src/composables/useAgentBuild.ts
@@ -1,7 +1,7 @@
 // A build is an NDJSON stream: log lines as the toolchain emits them, then one
 // result frame. The HTTP status only reports whether the request was accepted.
 
-export type BuildResult = { ok: true; build: string } | { ok: false; error: string };
+export type BuildResult = { ok: true; build: string } | { ok: false; error: string; code?: string };
 
 type Frame = { type: 'log'; line: string } | ({ type: 'result' } & BuildResult);
 
@@ -46,7 +46,7 @@ export async function runBuild(
         const frame = parseFrame(part);
         if (!frame) continue;
         if (frame.type === 'log') onLine(frame.line);
-        else result = frame.ok ? { ok: true, build: frame.build } : { ok: false, error: frame.error };
+        else result = frame.ok ? { ok: true, build: frame.build } : { ok: false, error: frame.error, code: frame.code };
       }
     }
   } finally {

--- a/web/src/pages/project/device/CodePanel.vue
+++ b/web/src/pages/project/device/CodePanel.vue
@@ -46,6 +46,26 @@ const building = ref(false);
 const saving = ref(false);
 const buildLog = ref<string[]>([]);
 const buildError = ref('');
+const noAgent = ref(false);
+
+const AGENT_RELEASES = 'https://github.com/decoded-cipher/nodrix-agent/releases/latest';
+
+// Apple silicon and Intel are indistinguishable from the user agent.
+const agentBinary = computed(() => {
+  const ua = navigator.userAgent;
+  if (ua.includes('Win')) return 'nodrix-agent-windows-x64.exe';
+  if (ua.includes('Mac')) return 'nodrix-agent-macos-arm64';
+  return 'nodrix-agent-linux-x64';
+});
+
+const agentSetup = computed(() => [
+  `curl -fsSL -o nodrix-agent ${AGENT_RELEASES}/download/${agentBinary.value}`,
+  'chmod +x nodrix-agent',
+  '',
+  `NODRIX_INSTANCE=${window.location.origin} \\`,
+  'NODRIX_TOKEN=<admin token from Account -> Tokens> \\',
+  './nodrix-agent',
+].join('\n'));
 // The artifact outlives the flash, so the same build can also be kept for OTA.
 const lastBuild = ref('');
 
@@ -66,6 +86,7 @@ async function build(): Promise<string | null> {
   building.value = true;
   buildLog.value = [];
   buildError.value = '';
+  noAgent.value = false;
   lastBuild.value = '';
   try {
     const res = await runBuild(
@@ -75,6 +96,7 @@ async function build(): Promise<string | null> {
     );
     if (!res.ok) {
       buildError.value = res.error;
+      noAgent.value = res.code === 'no_agent';
       return null;
     }
     lastBuild.value = res.build;
@@ -128,6 +150,11 @@ watch(code, (v) => localStorage.setItem(storageKey.value, v));
 async function copy() {
   await navigator.clipboard.writeText(code.value);
   toast.success('Sketch copied');
+}
+
+async function copyAgentSetup() {
+  await navigator.clipboard.writeText(agentSetup.value);
+  toast.success('Commands copied');
 }
 
 function download() {
@@ -207,7 +234,30 @@ function download() {
           Press Flash to build this sketch on your machine. A first build installs the toolchain and takes minutes.
         </p>
         <pre v-if="buildLog.length" class="whitespace-pre-wrap break-all font-mono text-xs text-neutral-600 dark:text-neutral-300">{{ buildLog.join('\n') }}</pre>
-        <p v-if="buildError" class="mt-2 font-mono text-xs text-red-600 dark:text-red-400">{{ buildError }}</p>
+        <p v-if="buildError && !noAgent" class="mt-2 font-mono text-xs text-red-600 dark:text-red-400">{{ buildError }}</p>
+
+        <div v-if="noAgent" class="rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950/40">
+          <p class="text-sm font-semibold text-amber-900 dark:text-amber-200">No agent is running</p>
+          <p class="mt-1 text-xs text-amber-900/80 dark:text-amber-200/80">
+            Compiling needs a C++ toolchain, which a browser can't run. The nodrix agent does it on
+            your machine and sends the binary back. It never touches the serial port — this page keeps
+            doing the flashing.
+          </p>
+          <pre class="mt-2 overflow-x-auto rounded-md bg-neutral-950 p-3 font-mono text-[11px] leading-relaxed text-neutral-300">{{ agentSetup }}</pre>
+          <div class="mt-2 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              class="rounded-md border border-amber-400 px-2.5 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-900/40"
+              @click="copyAgentSetup"
+            >Copy</button>
+            <a :href="AGENT_RELEASES" target="_blank" rel="noopener" class="text-xs font-medium text-amber-900 underline dark:text-amber-200">
+              Other platforms
+            </a>
+            <span class="text-[11px] text-amber-900/70 dark:text-amber-200/70">
+              Also needs arduino-cli, with <code>arduino-cli core install esp32:esp32</code>.
+            </span>
+          </div>
+        </div>
       </div>
 
       <div v-show="tab === 'serial'" class="min-h-0 flex-1 p-3">

--- a/worker/src/platform/durable-objects/project-do.ts
+++ b/worker/src/platform/durable-objects/project-do.ts
@@ -63,7 +63,7 @@ export type SeriesRow = {
 // The artifact goes to R2 on its own route; only its id crosses the DO.
 export type BuildOutcome =
   | { ok: true; build: string }
-  | { ok: false; error: string };
+  | { ok: false; error: string; code?: string };
 
 type PendingBuild = { controller: ReadableByteStreamController; lines: number; done: boolean };
 
@@ -475,7 +475,9 @@ export class ProjectDO extends DurableObject<Env> {
       type: 'bytes',
       start: (controller) => {
         const pending: PendingBuild = { controller, lines: 0, done: false };
-        if (!agent) return this.finishBuild(pending, { ok: false, error: 'no agent is connected' });
+        if (!agent) {
+          return this.finishBuild(pending, { ok: false, code: 'no_agent', error: 'no agent is connected' });
+        }
 
         this.pendingBuilds.set(id, pending);
         setTimeout(() => {


### PR DESCRIPTION
The agent is installable now — [v0.1.0](https://github.com/decoded-cipher/nodrix-agent/releases/tag/v0.1.0) ships binaries for five platforms. But nothing inside nodrix said so.

Pressing Flash without an agent running printed one line into the build console:

> no agent is connected

No link, no install command, no hint that an "agent" is something you download and run on your own machine. The instructions existed only in another repo's README, which nobody had a reason to open.

## What changed

The failure carries `code: 'no_agent'` instead of only a sentence, so the UI matches on a code rather than on prose that might get reworded.

The console answers it in place: what the agent is for and why compiling can't happen in the browser, a `curl` naming the binary for the platform the browser reports, `NODRIX_INSTANCE` already filled in from `window.location.origin`, a Copy button, a link for other platforms, and the `arduino-cli core install` the build will need immediately afterwards.

Apple silicon and Intel are indistinguishable from the user agent, so macOS gets the arm64 name with "Other platforms" alongside.

## README

Deploying an instance was documented; flashing a board from it was not. There is now a "Flashing hardware from the browser" section with the same install path, the Web Serial browser limitation stated plainly, and the agent listed under Architecture as a separate repo with its own release.

Typecheck, 104 tests and the build are green.